### PR TITLE
[#93705416] Create vagrant environment for Jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 inventory.vagrant
 .vagrant/
+roles
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+inventory.vagrant
+.vagrant/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+all: clean-roles ansible-galaxy vagrant-up
+
+clean-roles:
+	rm -rf -- roles/*
+
+ansible-galaxy:
+	ansible-galaxy install -r requirements.yml
+
+vagrant-up:
+	vagrant up --provision

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ A [vagrant](https://www.vagrantup.com/) file has been provided for local testing
 
 `vagrant up --provision`
 
+There is also a helper [Makefile](https://www.gnu.org/software/make/manual/make.html#Introduction) in the base directory of this project 
+that will automatically bring up the environment by running:
+
+`make` and browsing to `http://127.0.0.1:8080`
+
+
 ## Deploying
 
 `ansible-playbook -i inventory.<PROVIDER_NAME> site.yml` 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ persist if the virtual instance is ever destroyed and re-created.
  
 * `ansible`
 
+## Fetching Ansible Galaxy playbook dependencies
+
+Use the [ansible-galaxy](http://docs.ansible.com/galaxy.html#advanced-control-over-role-requirements-files) command to install third-party playbooks:
+
+`ansible-galaxy install -r requirements.yml`
+
 ## Testing
 
 A [vagrant](https://www.vagrantup.com/) file has been provided for local testing it can be brought up by running:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # multicloud-deploy
+
+Ansible project to create and maintain a [Jenkins](https://jenkins-ci.org/)
+service that will be used to continuous deploy our [Tsuru](https://tsuru.io/) [environment](https://github.com/alphagov/tsuru-terraform).
+
+This project uses the [Jenkins Job DSL](https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin) to define a job
+as code and store that job using a version management system. 
+
+No changes should be made to the jenkins server manually as they will not
+persist if the virtual instance is ever destroyed and re-created.
+
+## Requirements
+ 
+* `ansible`
+
+## Testing
+
+A [vagrant](https://www.vagrantup.com/) file has been provided for local testing it can be brought up by running:
+
+`vagrant up --provision`
+
+## Deploying
+
+`ansible-playbook -i inventory.<PROVIDER_NAME> site.yml` 
+
+Where:
+
+<PROVIDER_NAME> is: aws or gce

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ A [vagrant](https://www.vagrantup.com/) file has been provided for local testing
 Where:
 
 <PROVIDER_NAME> is: aws or gce
+
+## Known bugs
+
+* When editing dsl/config.xml and re-running Ansible it looks like the template job changes but not the Terraform job.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+MEMORY_DEFAULT = 384
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = "jenkins"
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = MEMORY_DEFAULT
+  end
+
+  config.vm.provider :vmware_fusion do |v|
+    v.vmx["memsize"] = MEMORY_DEFAULT
+  end
+
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
+
+  config.vm.provision :shell, inline: "apt-get purge -qq -y --auto-remove chef puppet"
+  config.vm.provision :ansible do |ansible|
+    ansible.groups = { "jenkins-master" => ["default"] }
+    ansible.playbook = "site.yml"
+  end
+end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,213 @@
+# config file for ansible -- http://ansible.com/
+# ==============================================
+
+# nearly all parameters can be overridden in ansible-playbook
+# or with command line flags. ansible will read ANSIBLE_CONFIG,
+# ansible.cfg in the current working directory, .ansible.cfg in
+# the home directory or /etc/ansible/ansible.cfg, whichever it
+# finds first
+
+[defaults]
+
+# some basic default values...
+
+hostfile       = /etc/ansible/hosts
+#library        = /usr/share/my_modules/
+remote_tmp     = $HOME/.ansible/tmp
+pattern        = *
+forks          = 5
+poll_interval  = 15
+sudo_user      = root
+#ask_sudo_pass = True
+#ask_pass      = True
+transport      = smart
+#remote_port    = 22
+module_lang    = C
+
+# plays will gather facts by default, which contain information about
+# the remote system.
+#
+# smart - gather by default, but don't regather if already gathered
+# implicit - gather by default, turn off with gather_facts: False
+# explicit - do not gather by default, must say gather_facts: True
+gathering = implicit
+
+# additional paths to search for rolemuls in, colon separated
+roles_path    = roles
+
+# uncomment this to disable SSH key host checking
+host_key_checking = False
+
+# change this for alternative sudo implementations
+sudo_exe = sudo
+
+# what flags to pass to sudo
+#sudo_flags = -H
+
+# SSH timeout
+timeout = 10
+
+# default user to use for playbooks if user is not specified
+# (/usr/bin/ansible will use current user as default)
+remote_user = ubuntu
+
+# logging is off by default unless this path is defined
+# if so defined, consider logrotate
+#log_path = /var/log/ansible.log
+
+# default module name for /usr/bin/ansible
+#module_name = command
+
+# use this shell for commands executed under sudo
+# you may need to change this to bin/bash in rare instances
+# if sudo is constrained
+#executable = /bin/sh
+
+# if inventory variables overlap, does the higher precedence one win
+# or are hash values merged together?  The default is 'replace' but
+# this can also be set to 'merge'.
+#hash_behaviour = replace
+
+# list any Jinja2 extensions to enable here:
+#jinja2_extensions = jinja2.ext.do,jinja2.ext.i18n
+
+# if set, always use this private key file for authentication, same as
+# if passing --private-key to ansible or ansible-playbook
+#private_key_file = ~/.ssh/GDS/deis
+
+# format of string {{ ansible_managed }} available within Jinja2
+# templates indicates to users editing templates files will be replaced.
+# replacing {file}, {host} and {uid} and strftime codes with proper values.
+ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
+
+# by default, ansible-playbook will display "Skipping [host]" if it determines a task
+# should not be run on a host.  Set this to "False" if you don't want to see these "Skipping"
+# messages. NOTE: the task header will still be shown regardless of whether or not the
+# task is skipped.
+#display_skipped_hosts = True
+
+# by default (as of 1.3), Ansible will raise errors when attempting to dereference
+# Jinja2 variables that are not set in templates or action lines. Uncomment this line
+# to revert the behavior to pre-1.3.
+#error_on_undefined_vars = False
+
+# by default (as of 1.6), Ansible may display warnings based on the configuration of the
+# system running ansible itself. This may include warnings about 3rd party packages or
+# other conditions that should be resolved if possible.
+# to disable these warnings, set the following value to False:
+#system_warnings = True
+
+# by default (as of 1.4), Ansible may display deprecation warnings for language
+# features that should no longer be used and will be removed in future versions.
+# to disable these warnings, set the following value to False:
+#deprecation_warnings = True
+
+# (as of 1.8), Ansible can optionally warn when usage of the shell and
+# command module appear to be simplified by using a default Ansible module
+# instead.  These warnings can be silenced by adjusting the following
+# setting or adding warn=yes or warn=no to the end of the command line
+# parameter string.  This will for example suggest using the git module
+# instead of shelling out to the git command.
+# command_warnings = False
+
+
+# set plugin path directories here, separate with colons
+action_plugins     = /usr/share/ansible_plugins/action_plugins
+callback_plugins   = /usr/share/ansible_plugins/callback_plugins
+connection_plugins = /usr/share/ansible_plugins/connection_plugins
+lookup_plugins     = /usr/share/ansible_plugins/lookup_plugins
+vars_plugins       = /usr/share/ansible_plugins/vars_plugins
+filter_plugins     = /usr/share/ansible_plugins/filter_plugins
+
+# by default callbacks are not loaded for /bin/ansible, enable this if you
+# want, for example, a notification or logging callback to also apply to
+# /bin/ansible runs
+#bin_ansible_callbacks = False
+
+
+# don't like cows?  that's unfortunate.
+# set to 1 if you don't want cowsay support or export ANSIBLE_NOCOWS=1
+#nocows = 1
+
+# don't like colors either?
+# set to 1 if you don't want colors, or export ANSIBLE_NOCOLOR=1
+#nocolor = 1
+
+# the CA certificate path used for validating SSL certs. This path
+# should exist on the controlling node, not the target nodes
+# common locations:
+# RHEL/CentOS: /etc/pki/tls/certs/ca-bundle.crt
+# Fedora     : /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+# Ubuntu     : /usr/share/ca-certificates/cacert.org/cacert.org.crt
+#ca_file_path =
+
+# the http user-agent string to use when fetching urls. Some web server
+# operators block the default urllib user agent as it is frequently used
+# by malicious attacks/scripts, so we set it to something unique to
+# avoid issues.
+#http_user_agent = ansible-agent
+
+# if set to a persistent type (not 'memory', for example 'redis') fact values
+# from previous runs in Ansible will be stored.  This may be useful when
+# wanting to use, for example, IP information from one group of servers
+# without having to talk to them in the same playbook run to get their
+# current IP information.
+fact_caching = memory
+
+[paramiko_connection]
+
+# uncomment this line to cause the paramiko connection plugin to not record new host
+# keys encountered.  Increases performance on new host additions.  Setting works independently of the
+# host key checking setting above.
+#record_host_keys=False
+
+# by default, Ansible requests a pseudo-terminal for commands executed under sudo. Uncomment this
+# line to disable this behaviour.
+#pty=False
+
+[ssh_connection]
+
+# ssh arguments to use
+# Leaving off ControlPersist will result in poor performance, so use
+# paramiko on older platforms rather than removing it
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -F ssh.config
+
+# The path to use for the ControlPath sockets. This defaults to
+# "%(directory)s/ansible-ssh-%%h-%%p-%%r", however on some systems with
+# very long hostnames or very long path names (caused by long user names or
+# deeply nested home directories) this can exceed the character limit on
+# file socket names (108 characters for most platforms). In that case, you
+# may wish to shorten the string below.
+#
+# Example:
+# control_path = %(directory)s/%%h-%%r
+#control_path = %(directory)s/ansible-ssh-%%h-%%p-%%r
+
+# Enabling pipelining reduces the number of SSH operations required to
+# execute a module on the remote server. This can result in a significant
+# performance improvement when enabled, however when using "sudo:" you must
+# first disable 'requiretty' in /etc/sudoers
+#
+# By default, this option is disabled to preserve compatibility with
+# sudoers configurations that have requiretty (the default on many distros).
+#
+#pipelining = False
+
+# if True, make ansible use scp if the connection type is ssh
+# (default is sftp)
+#scp_if_ssh = True
+
+[accelerate]
+accelerate_port = 5099
+accelerate_timeout = 30
+accelerate_connect_timeout = 5.0
+
+# The daemon timeout is measured in minutes. This time is measured
+# from the last activity to the accelerate daemon.
+accelerate_daemon_timeout = 30
+
+# If set to yes, accelerate_multi_key will allow multiple
+# private keys to be uploaded to it, though each user must
+# have access to the system via SSH to add a new key. The default
+# is "no".
+#accelerate_multi_key = yes

--- a/dsl/config.xml
+++ b/dsl/config.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <javaposse.jobdsl.plugin.ExecuteDslScripts plugin="job-dsl@1.32">
+      <scriptText>job {
+  name &apos;Terraform-run&apos;
+  scm {
+    git(&apos;https://github.com/alphagov/tsuru-terraform.git&apos;,&apos;master&apos;)
+  }
+  steps {
+    shell(&apos;terraform --help || true ; echo $?&apos;)
+  }
+}</scriptText>
+      <usingScriptText>true</usingScriptText>
+      <ignoreExisting>false</ignoreExisting>
+      <removedJobAction>IGNORE</removedJobAction>
+      <removedViewAction>IGNORE</removedViewAction>
+      <lookupStrategy>JENKINS_ROOT</lookupStrategy>
+      <additionalClasspath></additionalClasspath>
+    </javaposse.jobdsl.plugin.ExecuteDslScripts>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,6 @@
+# vim:ft=ansible:
+
+## from galaxy
+
+- src: geerlingguy.jenkins
+  version: 1.2.3

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,2 @@
+# vim:ft=ansible:
+---

--- a/site.yml
+++ b/site.yml
@@ -1,2 +1,37 @@
 # vim:ft=ansible:
 ---
+# Bring up jenkins ci master server.
+- hosts: jenkins-master
+  sudo: yes
+  roles:
+    - geerlingguy.jenkins
+  vars:
+    jenkins_plugins:
+      - git
+      - ssh
+      - job-dsl
+  tasks:
+    - name: install required packages
+      action: apt pkg={{item}} state=installed
+      with_items:
+        - git
+        - unzip
+    - name: download terraform
+      get_url: url=https://dl.bintray.com/mitchellh/terraform/terraform_0.4.2_linux_amd64.zip dest=/tmp/terraform.zip mode=0440
+      notify:
+        - unzip terraform.zip to /usr/local/bin
+    - name: copy default dsl seed config.xml to jenkins master
+      copy: src=dsl/config.xml dest=/tmp/config.xml owner=jenkins group=jenkins mode=0644
+    - name: create default dsl seed job
+      shell: "curl -X POST 'http://127.0.0.1:8080/createItem?name=default-dsl-job' --data-binary '@config.xml' -H 'Content-Type: text/xml'"
+      args:
+        chdir: /tmp/
+    - name: generate jenkins job from dsl seed job
+      uri: url='http://127.0.0.1:8080/job/default-dsl-job/build'
+        method=POST 
+        status_code=201
+  handlers:
+    - name: unzip terraform.zip to /usr/local/bin 
+      unarchive: src=/tmp/terraform.zip dest=/usr/local/bin copy=no
+
+


### PR DESCRIPTION
[Setup a Jenkins Server](https://www.pivotaltracker.com/story/show/93705416)

**What**

This PR is to setup a working [Jenkins](https://jenkins-ci.org/) instance in `vagrant` so we can do local development and testing of the Multi-Cloud PaaS [Continuous Delivery](http://refcardz.dzone.com/refcardz/continuous-delivery-patterns) pipeline.

There are several components to this pull request:
1. https://github.com/alphagov/multicloud-deploy/commit/db9f91bffcac42b9cd088cc2cba729995bf59870 Create a new machine in `vagrant` that will be used as a `Jenkins` master,
2. https://github.com/alphagov/multicloud-deploy/commit/da6e643988be9b5eeb5e936bdbeff22408bb49b7 Use `ansible-galaxy` command to pull down third party ansible playbooks,
3. https://github.com/alphagov/multicloud-deploy/commit/47ff25d2935055e55934b40f66aa26d105819262 Configure `Jenkins` with relevant plugins and a default [DSL seed job](https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin),
4. https://github.com/alphagov/multicloud-deploy/commit/74610734fc0e286108325513026bec3cba16c8c6 Create helper [Makefile](http://www.gnu.org/software/make/manual/make.html) to make vagrant environment spin up a simple task.

**How to review this PR**

I've tried to logically split the commits so they are easy to review individually while:
- Keeping a consistent narrative and,
- Not breaking master.

This PR should be reviewed in the following context:

_I would like to:_
- Create a base `vagrant` setup that will be used to to create a `Jenkins` server,
- Get some `ansible playbooks` that will make it easy for me to configure that `Jenkins` server,
- Use `ansible` to configure my Jenkins instance,
- Create a helper script that will make it easy to get the `Jenkins` server up and running.

**Who should review this PR**
- Any one in the core team with the exception of @lucorsel who I paired with.
