### PR TITLE
[#93705416] Add ssl support for Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A [vagrant](https://www.vagrantup.com/) file has been provided for local testing
 There is also a helper [Makefile](https://www.gnu.org/software/make/manual/make.html#Introduction) in the base directory of this project 
 that will automatically bring up the environment by running:
 
-`make vagrant` and browsing to `http://127.0.0.1:8080`
+`make vagrant` and browsing to `https://127.0.0.1:8443`
 
 ## Preparation
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(2) do |config|
     v.vmx["memsize"] = MEMORY_DEFAULT
   end
 
-  config.vm.network "forwarded_port", guest: 8080, host: 8080, auto_correct: true
+  config.vm.network "forwarded_port", guest: 443, host: 8443, auto_correct: true
 
   config.vm.provision :shell, inline: "apt-get purge -qq -y --auto-remove chef puppet"
   config.vm.provision :ansible do |ansible|

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,3 +4,5 @@
 
 - src: geerlingguy.jenkins
   version: 1.2.3
+- src: jdauphant.nginx
+  version: v1.3.4

--- a/site.yml
+++ b/site.yml
@@ -5,6 +5,9 @@
   sudo: yes
   roles:
     - geerlingguy.jenkins
+  pre_tasks:
+    - name: install snake oil ssl certificates
+      apt: name=ssl-cert state=present
   vars:
     jenkins_plugins:
       - git

--- a/site.yml
+++ b/site.yml
@@ -5,6 +5,7 @@
   sudo: yes
   roles:
     - geerlingguy.jenkins
+    - jdauphant.nginx
   pre_tasks:
     - name: install snake oil ssl certificates
       apt: name=ssl-cert state=present
@@ -13,6 +14,29 @@
       - git
       - ssh
       - job-dsl
+    nginx_sites:
+      ssl_reverse_proxy:
+        - listen 443 ssl
+        - ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem
+        - ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key
+        - server_name jenkins.tooling.paas.alphagov.co.uk
+        - location / {
+          proxy_pass http://localhost:8080;
+          proxy_redirect default;
+          proxy_redirect http://$host/ https://$host/;
+          proxy_redirect http://$hostname/ https://$host/;
+          proxy_read_timeout 15s;
+          proxy_connect_timeout 15s;
+          }
+      default:
+        - listen 80
+        - return 301 https://$host$request_uri
+    nginx_configs:
+      proxy:
+        - proxy_set_header Host $http_host
+        - proxy_set_header X-Real-IP  $remote_addr
+        - proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+        - proxy_set_header X-Forwarded-Proto https
   tasks:
     - name: install required packages
       action: apt pkg={{item}} state=installed


### PR DESCRIPTION
[Setup a Jenkins Server](https://www.pivotaltracker.com/story/show/93705416)

**What**

Create a [SSL enabled](http://en.wikipedia.org/wiki/Transport_Layer_Security) [Nginx](http://nginx.org/) [Reverse Proxy](http://en.wikipedia.org/wiki/Reverse_proxy) for [Jenkins](https://jenkins-ci.org/).

There are three components to this pull request.
1. https://github.com/alphagov/multicloud-deploy/commit/4940669b1c6212b65d4fc23a7a78070971f3e85a Getting an `nginx` playbook,
2. https://github.com/alphagov/multicloud-deploy/commit/5357badcf04e4d1c17d7c69010668ebfcc72601a Installing a `SSL` certificate and key,
3. https://github.com/alphagov/multicloud-deploy/commit/622384bb3810fbda906b106441e79cd775c9e842 Configuring `nginx` to act as a SSL enabled `reverse proxy`

**How to review this PR**

I've created the PR to be reviewed in the following context:
- I need to fetch a `nginx ansible playbook`
- I want to install a `self signed certificate and key` before I install and configure `nginx` so the `nginx` daemon won't choke on startup if a SSL enabled [virtual server](http://nginx.org/en/docs/http/ngx_http_core_module.html#server) is defined but a certificate and key are not available.
- Install and configure nginx as a SSL enabled `reverse proxy`

**Who should review this PR**
- Anyone in the core team.
