### PR TITLE
[#94593990] Disabling automatic tagging of builds for helper script

### DIFF
--- a/jobs/terraform-help/terraform-help.groovy
+++ b/jobs/terraform-help/terraform-help.groovy
@@ -1,7 +1,13 @@
 job {
   name 'terraform-help'
   scm {
-    git('https://github.com/alphagov/tsuru-terraform.git','master')
+    git {
+      remote {
+	url('https://github.com/alphagov/tsuru-terraform.git')
+      }
+      branch('master')
+      createTag(false)
+    }
   }
   steps {
     shell('terraform --help || true')


### PR DESCRIPTION
The helper script tries to tag repository on every run - which is something we don't want. It is the default behaviour and tagging needs to be explicitly disabled. 
