### PR TITLE
[#94593284] Upgrade Terraform to 0.5.2

### DIFF
--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -18,7 +18,7 @@ jenkins_mail_name: "Jenkins CI"
 jenkins_mail: "itsme@jenkins.com"
 smtp_server: "aspmx.l.google.com"
 
-terraform_filename: "terraform_0.4.2_linux_amd64.zip"
+terraform_filename: "terraform_0.5.1_linux_amd64.zip"
 
 permissions:
   admins:

--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -18,6 +18,8 @@ jenkins_mail_name: "Jenkins CI"
 jenkins_mail: "itsme@jenkins.com"
 smtp_server: "aspmx.l.google.com"
 
+terraform_filename: "terraform_0.4.2_linux_amd64.zip"
+
 permissions:
   admins:
     - hudson.scm.SCM.Tag

--- a/site.yml
+++ b/site.yml
@@ -54,9 +54,11 @@
         - python-pip
         - python-virtualenv
     - name: download terraform
-      get_url: url=https://dl.bintray.com/mitchellh/terraform/terraform_0.4.2_linux_amd64.zip dest=/tmp/terraform.zip mode=0440
+      get_url:
+        dest="/tmp/{{ terraform_filename }}" mode=0440
+        url="https://dl.bintray.com/mitchellh/terraform/{{ terraform_filename }}"
       notify:
-        - unzip terraform.zip to /usr/local/bin
+        - unzip terraform to /usr/local/bin
     - name: configure jenkins token
       copy: content="-u {{ jenkins_admin_user }}:{{ jenkins_api_token }}" dest=~/jenkins_auth
       when: jenkins_admin_user is defined and jenkins_api_token is defined
@@ -121,8 +123,8 @@
         mode: 0600
       when: gce_account_certificate_pem is defined
   handlers:
-    - name: unzip terraform.zip to /usr/local/bin 
-      unarchive: src=/tmp/terraform.zip dest=/usr/local/bin copy=no
+    - name: unzip terraform to /usr/local/bin
+      unarchive: src="/tmp/{{ terraform_filename }}" dest=/usr/local/bin copy=no
     - name: import certificate into java keystore
       shell: "keytool -import -alias {{ github_hostname }} -keystore {{ java_home }}/lib/security/cacerts -file ~/{{ github_hostname }}.crt -storepass {{ keystore_password }} -noprompt"
       when: vagrant is not defined


### PR DESCRIPTION
This is necessary because of changes to AWS security group egress rules in a
pull request (which this depends on):
- alphagov/tsuru-terraform#53

It will also allow us to use new resource types (Google Cloud DNS) and bug
fixes (GCE LB health checks) that we've been waiting for in later Terraform
versions.

Although the download link says "0.5.1" the version is actually "0.5.2"
because Terraform skipped a release:
- https://github.com/hashicorp/terraform/blob/1128c64ade36f1d917432450b97ec5add5defec8/CHANGELOG.md#051-never-released
