### PR TITLE
Remove gcloud tools from terraform job

### DIFF
--- a/jobs/terraform-deploy/terraform-deploy.groovy
+++ b/jobs/terraform-deploy/terraform-deploy.groovy
@@ -35,16 +35,6 @@ cp ~/.ssh/* gce/ssh
 cp ~/.ssh/* aws/ssh
 cp ~/.account.json gce/account.json
 
-# Install gcloud tools
-wget -N https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz
-tar xzf google-cloud-sdk.tar.gz
-printf '\\ny\\n\\ny\\ny\\n' | ./google-cloud-sdk/install.sh 
-source "${home}/google-cloud-sdk/path.bash.inc"
-
-gcloud -q components update
-gcloud auth activate-service-account --key-file ${home}/gce/account.json
-gcloud config set project root-unison-859
-
 # Terraform
 set -e
 [[ ${action} == "destroy" ]] && extraopts="-force"


### PR DESCRIPTION
After 0.5.2 terraform upgrade we can configure Google Compute Engine DNS records direcly and no longer need gcloud tools for any other operations.
