### PR TITLE
[#93705168] Upgrade terraform to version 0.5.3

### DIFF
--- a/group_vars/all/globals.yml
+++ b/group_vars/all/globals.yml
@@ -20,7 +20,7 @@ smtp_server: "aspmx.l.google.com"
 
 gpg_public_key_id: F35E9C9E
 
-terraform_filename: "terraform_0.5.1_linux_amd64.zip"
+terraform_filename: "terraform_0.5.3_linux_amd64.zip"
 
 permissions:
   admins:


### PR DESCRIPTION
[Registry uses GCS on GCE](https://www.pivotaltracker.com/story/show/93705168)

**What**

Install [terraform](https://github.com/hashicorp/terraform) version `0.5.3` with [google cloud storage support](https://github.com/hashicorp/terraform/pull/2060).

**Who should review this PR**
- Anyone on the core team.
