### PR TITLE
Fix spaces around environment name parameter

### DIFF
--- a/templates/jobs/ansible-deploy-aws.groovy.j2
+++ b/templates/jobs/ansible-deploy-aws.groovy.j2
@@ -2,7 +2,7 @@ job {
   name 'ansible-deploy-aws'
   description('Run ansible against Amazon EC2')
   parameters {
-    choiceParam("DEPLOY_ENV", [" {{ target_environment_name }} "],
+    choiceParam("DEPLOY_ENV", ["{{ target_environment_name }}"],
             "Select which environment you wish to run ansible against")
   }
   scm {

--- a/templates/jobs/ansible-deploy-gce.groovy.j2
+++ b/templates/jobs/ansible-deploy-gce.groovy.j2
@@ -2,7 +2,7 @@ job {
   name 'ansible-deploy-gce'
   description('Run ansible against Google Compute Engine')
   parameters {
-    choiceParam("DEPLOY_ENV", [" {{ target_environment_name }} "],
+    choiceParam("DEPLOY_ENV", ["{{ target_environment_name }}"],
             "Select which environment you wish to run ansible against")
   }
   scm {


### PR DESCRIPTION
Fix added spaces around the environment name parameter in the GCE and AWS ansible jobs.
