### PR TITLE
Do not run the ansible-galaxy tasks explicitly

### DIFF
--- a/templates/jobs/ansible-deploy-aws.groovy.j2
+++ b/templates/jobs/ansible-deploy-aws.groovy.j2
@@ -30,7 +30,7 @@ job {
 export PYTHONUNBUFFERED=1
 
 [[ -f /usr/bin/figlet ]] && figlet Assigning SSH private key
-eval $(ssh-agent) && ssh-add ~/.ssh/insecure-deployer 
+eval $(ssh-agent) && ssh-add ~/.ssh/insecure-deployer
 
 # Setting up trap to clean up ssh-agent process in the event of any failure
 set -e
@@ -51,10 +51,6 @@ pip install -Ur requirements.txt
 [[ -f /usr/bin/figlet ]] \
   && figlet Refreshing ec2 inventory cache
 ./ec2.py --refresh-cache > /dev/null 2>&1 && echo done...
-
-[[ -f /usr/bin/figlet ]] \
-  && figlet Configure ansible to use ${DEPLOY_ENV} environment
-make clean-roles ansible-galaxy 
 
 [[ -f /usr/bin/figlet ]] \
   && figlet Running ansible against ${DEPLOY_ENV} environment

--- a/templates/jobs/ansible-deploy-gce.groovy.j2
+++ b/templates/jobs/ansible-deploy-gce.groovy.j2
@@ -30,7 +30,7 @@ job {
 export PYTHONUNBUFFERED=1
 
 [[ -f /usr/bin/figlet ]] && figlet Assigning SSH private key
-eval $(ssh-agent) && ssh-add ~/.ssh/insecure-deployer 
+eval $(ssh-agent) && ssh-add ~/.ssh/insecure-deployer
 
 # Setting up trap to clean up ssh-agent process in the event of any failure
 set -e
@@ -48,10 +48,6 @@ virtualenv .venv
 
 [[ -f /usr/bin/figlet ]] && figlet Installing python dependencies
 pip install -Ur requirements.txt
-
-[[ -f /usr/bin/figlet ]] && \
- figlet Configure ansible to use ${DEPLOY_ENV} environment
-make clean-roles ansible-galaxy 
 
 [[ -f /usr/bin/figlet ]] && \
  figlet Running ansible against ${DEPLOY_ENV} environment


### PR DESCRIPTION
We download the roles as a `make` dependency of the `aws` and `gee`
tasks. We also removed the `clean-roles` which broke the build.

This PR removes this unnecessary step.
