### PR TITLE
Make vault decryption more quiet

### DIFF
--- a/open_the_vault.sh
+++ b/open_the_vault.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-gpg --batch --use-agent --decrypt vault_passphrase.gpg
+gpg --batch --quiet --use-agent --decrypt vault_passphrase.gpg


### PR DESCRIPTION
Set gpg to be quiet while decripting the vault. This prevents printing
all the recipients of the vault everytime we run ansible.

The same option [has been already added to
tsuru-ansible](https://github.com/alphagov/tsuru-ansible/pull/97)
