### PR TITLE
Add jenkins plugin `parameterized-trigger` back

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -21,6 +21,7 @@
       - job-dsl
       - github-api
       - github-oauth
+      - parameterized-trigger
       - role-strategy
       - ansicolor
     nginx_sites:


### PR DESCRIPTION
During [platform alert PR](https://github.com/alphagov/multicloud-deploy/pull/29) we
accidentaly removed the entry to install the plugin
parameterized-trigger in jenkins. Because that, the deploy demo job fails.

This PR adds the entry back.
