### PR TITLE
[#96998072] Create enviroment specific terraform statefiles

### DIFF
--- a/templates/jobs/terraform-deploy.groovy.j2
+++ b/templates/jobs/terraform-deploy.groovy.j2
@@ -50,12 +50,12 @@ set -e
 
 # GCE
 cd gce
-terraform ${action} -var env=${environment_name} -input=false ${extraopts}
+terraform ${action} -var env=${environment_name} -input=false -state=${environment_name}-terraform.tfstate ${extraopts}
 
 # AWS
 cd ../aws
 . ~/.aws_credentials
-terraform ${action} -var env=${environment_name} -input=false ${extraopts}
+terraform ${action} -var env=${environment_name} -input=false -state=${environment_name}-terraform.tfstate ${extraopts}
 ''')
   }
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/96998072
**Problem** :
We are using a single statefile to handle multiple environments and that doesn't work because
you can only target one environment at a time.

**Observed outputs** :
Previously when deploying environments, the deployments would overwrite
the single terrafrom statefile, causing the deployment to not reach a desired
outcome even if the job succeeds.

**Solution** :
This commit adds a flag to the command line running of Terraform to specify a environment
terraform state file.

**Who can review it**:

Anyone on core team apart from @actionjack 
