### PR TITLE
[#98109110] Suspend environments

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -155,7 +155,12 @@
         email_notification_address: "multi-cloud-paas-demo@digital.cabinet-office.gov.uk"
     - include: jenkins_job.yml
       vars:
-        job_name: suspend-environments
+        job_name: suspend-aws-environments
+        exclude_env: "demo ci"
+        cron_suspend_time: "0 19 * * *"
+    - include: jenkins_job.yml
+      vars:
+        job_name: suspend-gce-environments
         exclude_env: "demo ci"
         cron_suspend_time: "0 19 * * *"
 

--- a/site.yml
+++ b/site.yml
@@ -153,6 +153,11 @@
         target: "demo"
         build_interval: "H/2 * * * *"
         email_notification_address: "multi-cloud-paas-demo@digital.cabinet-office.gov.uk"
+    - include: jenkins_job.yml
+      vars:
+        job_name: suspend-environments
+        exclude_env: "demo ci"
+        cron_suspend_time: "0 19 * * *"
 
     - name: create jenkins .ssh directory
       file: path=/var/lib/jenkins/.ssh state=directory mode=0775 owner="jenkins"

--- a/templates/jobs/suspend-aws-environments.groovy.j2
+++ b/templates/jobs/suspend-aws-environments.groovy.j2
@@ -1,0 +1,72 @@
+job {
+  name '{{job_name}}'
+  description('Suspends environments')
+  parameters {
+    stringParam("EXCLUDE_ENV", "{{ exclude_env }}",
+            "Space separated list of environments to exclude from shutdown")
+  }
+  scm {
+    git {
+      remote {
+	    url('https://github.com/alphagov/tsuru-ansible.git')
+      }
+      branch('master')
+      createTag(false)
+    }
+  }
+  triggers {
+   cron("{{ cron_suspend_time }}")
+  }
+  wrappers {
+    colorizeOutput()
+  }
+  publishers {
+    mailer("{{ email_notification_address | default("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk")}}")
+  }
+  steps {
+    shell('''#!/bin/bash
+# Disable output buffering to give realtime data
+export PYTHONUNBUFFERED=1
+
+# Assign SSH private key
+eval $(ssh-agent) && ssh-add ~/.ssh/insecure-deployer
+
+# Set up trap to clean up ssh-agent process in the event of any failure
+set -e
+trap "kill ${SSH_AGENT_PID}" EXIT
+
+# Set up virtualenv
+virtualenv .venv
+. .venv/bin/activate
+
+# Install python dependencies
+pip install -Ur requirements.txt
+
+# AWS
+# Source EC2 credentials
+. ~/.aws_credentials
+
+# 1. Get environments
+NAT_HOSTS=`./ec2.py --refresh-cache | grep \\"tag_Name_.*-tsuru-nat`
+ENVIRONMENTS=`echo "$NAT_HOSTS" | sed 's/.\\+"tag_Name_// ; s/-tsuru-nat.*//'`
+
+# 2. Exclude
+EXC=`echo "$EXCLUDE_ENV" | sed "s/ /|/g"`
+ENV=`echo "$ENVIRONMENTS" | grep -Ev $EXC`
+
+# 3. Suspend
+echo "Suspending environments on AWS:"
+set +e
+result=0
+for environment in $ENV ; do
+  echo "Suspending ${environment}..."
+  make suspend-aws DEPLOY_ENV=$environment
+  result=`expr $? + $result`
+done
+
+kill ${SSH_AGENT_PID}
+exit $result
+''')
+  }
+}
+

--- a/templates/jobs/suspend-environments.groovy.j2
+++ b/templates/jobs/suspend-environments.groovy.j2
@@ -1,0 +1,88 @@
+job {
+  name '{{job_name}}'
+  description('Suspends environments')
+  parameters {
+    stringParam("EXCLUDE_ENV", "{{ exclude_env }}",
+            "Space separated list of environments to exclude from shutdown")
+  }
+  scm {
+    git {
+      remote {
+	    url('https://github.com/alphagov/tsuru-ansible.git')
+      }
+      branch('master')
+      createTag(false)
+    }
+  }
+  triggers {
+   cron("{{ cron_suspend_time }}")
+  }
+  wrappers {
+    colorizeOutput()
+  }
+  publishers {
+    mailer("{{ email_notification_address | default("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk")}}")
+  }
+  steps {
+    shell('''#!/bin/bash
+# Disable output buffering to give realtime data
+export PYTHONUNBUFFERED=1
+
+# Assign SSH private key
+eval $(ssh-agent) && ssh-add ~/.ssh/insecure-deployer
+
+# Set up trap to clean up ssh-agent process in the event of any failure
+set -e
+trap "kill ${SSH_AGENT_PID}" ERR
+
+# Set up virtualenv
+virtualenv .venv
+. .venv/bin/activate
+
+# Install python dependencies
+pip install -Ur requirements.txt
+
+# AWS
+# Source EC2 credentials
+. ~/.aws_credentials
+
+# 1. Get environments
+NAT_HOSTS=`./ec2.py --refresh-cache | grep \\"tag_Name_.*-tsuru-nat`
+ENVIRONMENTS=`echo "$NAT_HOSTS" | sed 's/.\\+"tag_Name_// ; s/-tsuru-nat.*//'`
+
+# 2. Exclude
+EXC=`echo "$EXCLUDE_ENV" | sed "s/ /|/g"`
+ENV=`echo "$ENVIRONMENTS" | grep -Ev $EXC`
+
+# 3. Suspend
+echo "Suspending environments on AWS:"
+for environment in $ENV ; do
+  echo "Suspending ${environment}..."
+  make suspend-aws DEPLOY_ENV=$environment
+done
+
+# GCE
+# Source GCE credentials
+cp ~/.secrets.py secrets.py
+cp ~/.gce_account.pem gce_account.pem
+
+# 1. Get environments
+NAT_HOSTS=`./gce.py | python -mjson.tool | grep \\"gce_name.*-tsuru-nat`
+ENVIRONMENTS=`echo "$NAT_HOSTS" | sed 's/-tsuru-nat.*// ; s/.\\+"//'`
+
+# 2. Exclude
+EXC=`echo "$EXCLUDE_ENV" | sed "s/ /|/g"`
+ENV=`echo "$ENVIRONMENTS" | grep -Ev $EXC`
+
+# 3. Suspend
+echo "Suspending environments on GCE:"
+for environment in $ENV ; do
+  echo "Suspending ${environment}..."
+  make suspend-gce DEPLOY_ENV=$environment
+done
+
+kill ${SSH_AGENT_PID}
+''')
+  }
+}
+

--- a/templates/jobs/suspend-gce-environments.groovy.j2
+++ b/templates/jobs/suspend-gce-environments.groovy.j2
@@ -33,7 +33,7 @@ eval $(ssh-agent) && ssh-add ~/.ssh/insecure-deployer
 
 # Set up trap to clean up ssh-agent process in the event of any failure
 set -e
-trap "kill ${SSH_AGENT_PID}" ERR
+trap "kill ${SSH_AGENT_PID}" EXIT
 
 # Set up virtualenv
 virtualenv .venv
@@ -41,25 +41,6 @@ virtualenv .venv
 
 # Install python dependencies
 pip install -Ur requirements.txt
-
-# AWS
-# Source EC2 credentials
-. ~/.aws_credentials
-
-# 1. Get environments
-NAT_HOSTS=`./ec2.py --refresh-cache | grep \\"tag_Name_.*-tsuru-nat`
-ENVIRONMENTS=`echo "$NAT_HOSTS" | sed 's/.\\+"tag_Name_// ; s/-tsuru-nat.*//'`
-
-# 2. Exclude
-EXC=`echo "$EXCLUDE_ENV" | sed "s/ /|/g"`
-ENV=`echo "$ENVIRONMENTS" | grep -Ev $EXC`
-
-# 3. Suspend
-echo "Suspending environments on AWS:"
-for environment in $ENV ; do
-  echo "Suspending ${environment}..."
-  make suspend-aws DEPLOY_ENV=$environment
-done
 
 # GCE
 # Source GCE credentials
@@ -76,12 +57,16 @@ ENV=`echo "$ENVIRONMENTS" | grep -Ev $EXC`
 
 # 3. Suspend
 echo "Suspending environments on GCE:"
+set +e
+result=0
 for environment in $ENV ; do
   echo "Suspending ${environment}..."
   make suspend-gce DEPLOY_ENV=$environment
+  result=`expr $? + $result`
 done
 
 kill ${SSH_AGENT_PID}
+exit $result
 ''')
   }
 }


### PR DESCRIPTION
In order to save on running costs, we want to suspend our environments daily after work. This is being done by the `suspend environments` jenkins job added in this PR. Job defaults:
- excluded environments = "demo ci" - we want to keep these environments running
- execution time = "0 19 \* \* *" - every day at 7pm

This PR depends on: https://github.com/alphagov/tsuru-ansible/pull/114
