### PR TITLE
[#98109270] Add Jenkins status to the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ansible project to create and maintain a [Jenkins](https://jenkins-ci.org/)
 service that will be used to continuous deploy our [Tsuru](https://tsuru.io/) [environment](https://github.com/alphagov/tsuru-terraform).
 
 This project uses the [Jenkins Job DSL](https://wiki.jenkins-ci.org/display/JENKINS/Job+DSL+Plugin) to define a job
-as code and store that job using a version management system. 
+as code and store that job using a version management system.
 
 This project implements the use of an [ansible dynamic inventory](https://aws.amazon.com/blogs/apn/getting-started-with-ansible-and-dynamic-amazon-ec2-inventory-management/)
 Script and configuration file used for dynamic inventory on aws (ec2.py and ec2.ini) are part of [ansible plugins](https://github.com/ansible/ansible/tree/devel/plugins/inventory)
@@ -17,7 +17,7 @@ The Jenkins server is configured to use [GitHub authorization](https://wiki.jenk
 [Openconnect VPN client](http://www.infradead.org/openconnect/) is installed to allow Jenkins access our internal GitHub.
 
 ## Requirements
- 
+
 * `ansible`
 
 * Python things (you may wish to use [virtualenv](https://virtualenv.pypa.io/en/latest/)):
@@ -37,7 +37,7 @@ A [vagrant](https://www.vagrantup.com/) file has been provided for local testing
 
 `vagrant up --provision`
 
-There is also a helper [Makefile](https://www.gnu.org/software/make/manual/make.html#Introduction) in the base directory of this project 
+There is also a helper [Makefile](https://www.gnu.org/software/make/manual/make.html#Introduction) in the base directory of this project
 that will automatically bring up the environment by running:
 
 `make vagrant` and browsing to `https://127.0.0.1:8443`
@@ -188,7 +188,7 @@ Some of the jobs we deploy require our AWS and [GCE](https://cloud.google.com/co
 * `gce_account` - google compute engine account.json file
 * `deployer_key:`- deployer key with elements: `name:` - name of the key and `key:` - the key itself
 * `secrets_py` - [Google Compute Engine](https://cloud.google.com/compute/) [credentials for Ansible](http://docs.ansible.com/guide_gce.html#calling-modules-with-secrets-py)
-* `gce_account_certificate_pem` - [Google Compute Engine](https://cloud.google.com/compute/) service account private key 
+* `gce_account_certificate_pem` - [Google Compute Engine](https://cloud.google.com/compute/) service account private key
 
 For example:
 ```
@@ -237,3 +237,29 @@ Where:
 
 * At this moment, only the 'aws' platform is supported
 * You will need to log in to jenkins to obtain the `jenkins_api_token` and add it to your ansible `globals.yml` or `vault` file to enable subsequent jenkins and job configuration
+
+## Dashboard
+
+This repository also contains a `dashboard.html` web page which can be used as an alternative to Fourth Wall dashboard.
+
+It combines Fourth Wall and Jenkins Buld Monitor View Plugin to display two dashboards side by side.
+
+In order to use it, just copy this file locally to the computer running the dashboard, and open the file in a browser, passing required query string parameters:
+
+- token (Github token)
+- gist (ID of a Gist listing all repositories we are interested in)
+
+Optional parameters:
+
+- JENKINS_URL (defaults to `https://deploy.tools.paas.alphagov.co.uk`)
+- FOURTH_WALL_URL (defaults to `https://alphagov.github.io/fourth-wall`)
+- LEFT_WIDTH (defaults to `50`)
+- RIGHT_WIDTH (defaults to `50`)
+
+The dashboard simply displays two iframes side by side.
+
+Alternatively, if you don't want to copy the file locally, you can just use raw Github URL, something like:
+
+```
+https://cdn.rawgit.com/alphagov/multicloud-deploy/master/dashboard.html?token=XXXX&gist=XXXXX
+```

--- a/dashboard.html
+++ b/dashboard.html
@@ -6,21 +6,21 @@
     <style>
     body { background: #333; }
     .box { height: 1000px; float: left; }
-    .box-left { width: 50%; }
-    .box-right { width: 50%; }
+    #box-left { width: 50%; }
+    #box-right { width: 50%; }
     iframe { margin: 0; border: 0; }
     </style>
 </head>
 <body>
 
-<div class="box box-left">
+<div class="box" id="box-left">
   <iframe id="jenkins"
     src=""
     width="100%" height="100%">
   </iframe>
 </div>
 
-<div class="box box-right">
+<div class="box" id="box-right">
   <iframe id="pull-requests"
     src=""
     width="100%" height="100%">
@@ -37,16 +37,22 @@ function getParameterByName(name) {
 
 var JENKINS_URL = getParameterByName("JENKINS_URL")
       || "https://deploy.tools.paas.alphagov.co.uk",
-    FOURTH_WALL_URL = "http://alphagov.github.io/fourth-wall/";
+    FOURTH_WALL_URL = getParameterByName("JENKINS_URL")
+      || "http://alphagov.github.io/fourth-wall",
+    LEFT_WIDTH = getParameterByName("LEFT_WIDTH") || "50",
+    RIGHT_WIDTH = getParameterByName("RIGHT_WIDTH") || "50";
 
 var loc = window.location.toString(),
     urlParts = loc.split('?'),
     queryString = urlParts[urlParts.length-1],
-    jenkinsIframe = document.getElementById('jenkins'),
-    pullRequestsIframe = document.getElementById('pull-requests');
+    jenkinsIframe = document.getElementById("jenkins"),
+    pullRequestsIframe = document.getElementById("pull-requests");
 
     jenkinsIframe.src = JENKINS_URL + "/view/Build%20Monitor%20View/";
     pullRequestsIframe.src = FOURTH_WALL_URL + "?" + queryString;
+
+    document.getElementById("box-left").style.width = LEFT_WIDTH + "%";
+    document.getElementById("box-right").style.width = RIGHT_WIDTH + "%";
 </script>
 
 </body>

--- a/dashboard.html
+++ b/dashboard.html
@@ -38,7 +38,7 @@ function getParameterByName(name) {
 var JENKINS_URL = getParameterByName("JENKINS_URL")
       || "https://deploy.tools.paas.alphagov.co.uk",
     FOURTH_WALL_URL = getParameterByName("FOURTH_WALL_URL")
-      || "http://alphagov.github.io/fourth-wall",
+      || "https://alphagov.github.io/fourth-wall",
     LEFT_WIDTH = getParameterByName("LEFT_WIDTH") || "50",
     RIGHT_WIDTH = getParameterByName("RIGHT_WIDTH") || "50";
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+    <title>Dashboard</title>
+    <link rel="icon" type="image/png" href="favicon-32.png">
+    <style>
+    body { background: #333; }
+    .box { height: 1000px; float: left; }
+    .box-left { width: 50%; }
+    .box-right { width: 50%; }
+    iframe { margin: 0; border: 0; }
+    </style>
+</head>
+<body>
+
+<div class="box box-left">
+  <iframe id="jenkins"
+    src=""
+    width="100%" height="100%">
+  </iframe>
+</div>
+
+<div class="box box-right">
+  <iframe id="pull-requests"
+    src=""
+    width="100%" height="100%">
+  </iframe>
+</div>
+
+<script type="text/javascript">
+var JENKINS_URL = "https://deploy.tools.paas.alphagov.co.uk",
+    FOURTH_WALL_URL = "http://alphagov.github.io/fourth-wall/";
+
+var loc = window.location.toString(),
+    params = loc.split('?')[1],
+    jenkinsIframe = document.getElementById('jenkins'),
+    pullRequestsIframe = document.getElementById('pull-requests');
+
+    jenkinsIframe.src = JENKINS_URL + "/view/Build%20Monitor%20View/";
+    pullRequestsIframe.src = FOURTH_WALL_URL + "?" + params;
+</script>
+
+</body>
+</html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -37,7 +37,7 @@ function getParameterByName(name) {
 
 var JENKINS_URL = getParameterByName("JENKINS_URL")
       || "https://deploy.tools.paas.alphagov.co.uk",
-    FOURTH_WALL_URL = getParameterByName("JENKINS_URL")
+    FOURTH_WALL_URL = getParameterByName("FOURTH_WALL_URL")
       || "http://alphagov.github.io/fourth-wall",
     LEFT_WIDTH = getParameterByName("LEFT_WIDTH") || "50",
     RIGHT_WIDTH = getParameterByName("RIGHT_WIDTH") || "50";

--- a/dashboard.html
+++ b/dashboard.html
@@ -28,16 +28,25 @@
 </div>
 
 <script type="text/javascript">
-var JENKINS_URL = "https://deploy.tools.paas.alphagov.co.uk",
+function getParameterByName(name) {
+    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+    var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+        results = regex.exec(location.search);
+    return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+}
+
+var JENKINS_URL = getParameterByName("JENKINS_URL")
+      || "https://deploy.tools.paas.alphagov.co.uk",
     FOURTH_WALL_URL = "http://alphagov.github.io/fourth-wall/";
 
 var loc = window.location.toString(),
-    params = loc.split('?')[1],
+    urlParts = loc.split('?'),
+    queryString = urlParts[urlParts.length-1],
     jenkinsIframe = document.getElementById('jenkins'),
     pullRequestsIframe = document.getElementById('pull-requests');
 
     jenkinsIframe.src = JENKINS_URL + "/view/Build%20Monitor%20View/";
-    pullRequestsIframe.src = FOURTH_WALL_URL + "?" + params;
+    pullRequestsIframe.src = FOURTH_WALL_URL + "?" + queryString;
 </script>
 
 </body>

--- a/dsl/config.xml
+++ b/dsl/config.xml
@@ -12,7 +12,7 @@
     <concurrentBuild>false</concurrentBuild>
     <builders>
         <javaposse.jobdsl.plugin.ExecuteDslScripts plugin="job-dsl@1.32">
-            <targets>jobs/**/*.groovy</targets>
+            <targets>jobs/**/*.groovy,views/**/*.groovy</targets>
             <usingScriptText>false</usingScriptText>
             <ignoreExisting>false</ignoreExisting>
             <removedJobAction>IGNORE</removedJobAction>

--- a/jenkins_job.yml
+++ b/jenkins_job.yml
@@ -14,5 +14,4 @@
   tags:
     - job_definition
   notify:
-    - process DSL jobs
-
+    - process DSL

--- a/jenkins_view.yml
+++ b/jenkins_view.yml
@@ -1,0 +1,17 @@
+---
+- name: create jenkins view directory structure for {{ view_name }}
+  file:
+    path: /var/lib/jenkins/jobs/default-dsl-job/workspace/views/{{ view_name }}
+    state: directory
+    mode: 0775
+    owner: "jenkins"
+  tags:
+    - view_definition
+- name: generate jenkins views from template {{ view_template | default(view_name) }}
+  template:
+    dest: "/var/lib/jenkins/jobs/default-dsl-job/workspace/views/{{ view_name }}.groovy"
+    src: "templates/views/{{ view_template | default(view_name) }}.groovy.j2"
+  tags:
+    - view_definition
+  notify:
+    - process DSL

--- a/site.yml
+++ b/site.yml
@@ -24,6 +24,7 @@
       - parameterized-trigger
       - role-strategy
       - ansicolor
+      - build-monitor-plugin
     nginx_sites:
       ssl_reverse_proxy:
         - listen 443 ssl
@@ -153,6 +154,9 @@
         target: "demo"
         build_interval: "H/2 * * * *"
         email_notification_address: "multi-cloud-paas-demo@digital.cabinet-office.gov.uk"
+    - include: jenkins_view.yml
+      vars:
+        view_name: build-monitor
 
     - name: create jenkins .ssh directory
       file: path=/var/lib/jenkins/.ssh state=directory mode=0775 owner="jenkins"
@@ -238,9 +242,8 @@
     - name: import gpg public key
       shell: gpg --batch --yes --keyserver hkp://keyserver.ubuntu.com  --recv-keys {{ gpg_public_key_id }}
       sudo_user: jenkins
-    - name: process DSL jobs
-      shell: "curl -X POST 'http://127.0.0.1:8080/job/default-dsl-job/build' -k $(cat ~/jenkins_auth)"
+    - name: process DSL
+      shell: "curl -X POST 'http://127.0.0.1:8080/job/default-dsl-job/build' -k $([ ! -e ~/jenkins_auth ] || cat ~/jenkins_auth)"
     - name: wait for creation and disable terraform jenkins job on vagrant boxes
       shell: "sleep 15 && curl -X POST 'http://127.0.0.1:8080/job/terraform-deploy/disable' -k $(cat ~/jenkins_auth)"
       when: vagrant is defined
-

--- a/templates/views/build-monitor.groovy.j2
+++ b/templates/views/build-monitor.groovy.j2
@@ -1,0 +1,6 @@
+buildMonitorView('Build Monitor View') {
+    description('Dashboard Listing Build Statuses')
+    jobs {
+        regex('.*')
+    }
+}


### PR DESCRIPTION
## What

Added build-monitor-plugin, DSL to generate a new view to display Jenkins job statuses alongside the Fourth Wall pull requests.

The new dashboard file is `dashboard.html`.
## Review

Anybody other than Richard or Hector.
## How To Test

Clone multicloud-deploy, checkout this branch and run:

```
vagrant provision
```

Jenkins should now have a new view called `Build Monitor View`. Test it works at this URL: `https://localhost:8443/view/Build%20Monitor%20View/`.

Test the split screen dashboard. Just open `dasboard.html` in your browser and pass required parameters:
- token
- gist

For example, URL could look like this:

```
file:///Users/richardknop/github.com/alphagov/multicloud-deploy/dashboard.html?token=sometoken&gist=gistid&JENKINS_URL=https://localhost:8443/
```

Optional parameters:
- JENKINS_URL (default "https://deploy.tools.paas.alphagov.co.uk")
- FOURTH_WALL_URL (default "http://alphagov.github.io/fourth-wall")
- LEFT_WIDTH (default "50")
- RIGHT_WIDTH (default "50")
