### PR TITLE
[#98272378] Create environment specific jenkins views

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -180,7 +180,7 @@
     - include: jenkins_view.yml
       vars:
         environment_regex: '^ci-.*'
-          view_name: ci
+        view_name: ci
         view_template: environment-view
     - include: jenkins_view.yml
       vars:

--- a/site.yml
+++ b/site.yml
@@ -180,12 +180,12 @@
     - include: jenkins_view.yml
       vars:
         environment_regex: '^ci-.*'
-        view_name: ci-view
+          view_name: ci
         view_template: environment-view
     - include: jenkins_view.yml
       vars:
         environment_regex: '^demo-.*'
-        view_name: demo-view
+        view_name: demo
         view_template: environment-view
 
     - name: execute dsl seed job for vagrant

--- a/site.yml
+++ b/site.yml
@@ -177,6 +177,16 @@
     - include: jenkins_view.yml
       vars:
         view_name: build-monitor
+    - include: jenkins_view.yml
+      vars:
+        environment_regex: '^ci-.*'
+        view_name: ci-view
+        view_template: environment-view
+    - include: jenkins_view.yml
+      vars:
+        environment_regex: '^demo-.*'
+        view_name: demo-view
+        view_template: environment-view
 
     - name: execute dsl seed job for vagrant
       shell: "sleep 20 && curl -X POST 'http://127.0.0.1:8080/job/default-dsl-job/build'"

--- a/templates/views/environment-view.groovy.j2
+++ b/templates/views/environment-view.groovy.j2
@@ -1,0 +1,9 @@
+listView(' {{ view_name }}') {
+    description('{{ view_name }}')
+    jobs {
+        regex('{{ environment_regex }}')
+    }
+    columns {
+      name()
+    }
+}

--- a/templates/views/environment-view.groovy.j2
+++ b/templates/views/environment-view.groovy.j2
@@ -4,6 +4,12 @@ listView(' {{ view_name }}') {
         regex('{{ environment_regex }}')
     }
     columns {
+      status()
+      weather()
       name()
+      lastSuccess()
+      lastFailure()
+      lastDuration()
+      buildButton()
     }
 }


### PR DESCRIPTION
[Create different jobs for deploying ci and demo in jenkins](https://www.pivotaltracker.com/story/show/98272378)

**What**

Create CI and Demo specific views in jenkins

**How to review this PR**

I have written this PR in the following context:
- I would like to be able to view each environments jobs separately without other environments cluttering my view

**How to test this PR**

A vagrant box has been provided for local testing, simply just:

```
vagrant up
```

Then browse to https://localhost:8443

You should see the following views there:
- ci-view - Continuous Integration Environment Jobs
- demo-view - Demo Environment Jobs

**Who should review this PR**
- A Lazy Lemur, if a suitably relaxed primate can not be found then a member of the core team can step in.
