### PR TITLE
[#99119628] Suspend environments

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -174,6 +174,20 @@
         target_environment_name: demo
         build_interval: "H/2 * * * *"
         email_notification_address: "multi-cloud-paas-demo@digital.cabinet-office.gov.uk"
+    - include: jenkins_job.yml
+      vars:
+        job_name: suspend-aws-environments
+        job_template: suspend-environments
+        platform: "aws"
+        exclude_env: "demo ci"
+        cron_suspend_time: "0 19 * * *"
+    - include: jenkins_job.yml
+      vars:
+        job_name: suspend-gce-environments
+        job_template: suspend-environments
+        platform: "gce"
+        exclude_env: "demo ci"
+        cron_suspend_time: "0 19 * * *"
     - include: jenkins_view.yml
       vars:
         view_name: build-monitor

--- a/templates/jobs/suspend-environments.groovy.j2
+++ b/templates/jobs/suspend-environments.groovy.j2
@@ -1,0 +1,86 @@
+job {
+  name '{{ job_name }}'
+  description('Suspends environments on {{ platform }}')
+  {% if vagrant is defined %}
+    disabled(shouldDisable = true)
+  {% endif %}
+  parameters {
+    stringParam("EXCLUDE_ENV", "{{ exclude_env }}",
+            "Space separated list of environments to exclude from shutdown")
+  }
+  scm {
+    git {
+      remote {
+	    url('https://github.com/alphagov/tsuru-ansible.git')
+      }
+      branch('master')
+      createTag(false)
+    }
+  }
+  triggers {
+   cron("{{ cron_suspend_time }}")
+  }
+  wrappers {
+    colorizeOutput()
+  }
+  publishers {
+    mailer("{{ email_notification_address | default("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk")}}")
+  }
+  steps {
+    shell('''#!/bin/bash
+# Disable output buffering to give realtime data
+export PYTHONUNBUFFERED=1
+
+# Assign SSH private key
+eval $(ssh-agent) && ssh-add ~/.ssh/insecure-deployer
+
+# Set up trap to clean up ssh-agent process in the event of any failure
+set -e
+trap "kill ${SSH_AGENT_PID}" EXIT
+
+# Set up virtualenv
+virtualenv .venv
+. .venv/bin/activate
+
+# Install python dependencies
+pip install -Ur requirements.txt
+
+# {{ platform|upper() }}
+# Source {{ platform|upper() }} credentials
+{% if platform == "aws" %}
+. ~/.aws_credentials
+
+# 1. Get environments
+NAT_HOSTS=`./ec2.py --refresh-cache | grep \\"tag_Name_.*-tsuru-nat`
+ENVIRONMENTS=`echo "$NAT_HOSTS" | sed 's/.\\+"tag_Name_// ; s/-tsuru-nat.*//'`
+{% endif %}
+
+{% if platform == "gce" %}
+cp ~/.secrets.py secrets.py
+cp ~/.gce_account.pem gce_account.pem
+
+# 1. Get environments
+NAT_HOSTS=`./gce.py | python -mjson.tool | grep \\"gce_name.*-tsuru-nat`
+ENVIRONMENTS=`echo "$NAT_HOSTS" | sed 's/-tsuru-nat.*// ; s/.\\+"//'`
+{% endif %}
+
+# 2. Exclude
+EXC=`echo "$EXCLUDE_ENV" | sed "s/ /|/g"`
+ENV=`echo "$ENVIRONMENTS" | grep -Ev $EXC`
+
+# 3. Suspend
+echo "Suspending environments on {{ platform }}:"
+set +e
+result=0
+for environment in $ENV ; do
+  echo "Suspending ${environment}..."
+  make suspend-{{ platform }} DEPLOY_ENV=$environment
+  result=`expr $? + $result`
+done
+
+kill ${SSH_AGENT_PID}
+exit $result
+''')
+  }
+}
+


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/n/projects/1275640/stories/99119628): In order to save on running costs, we want to shut down environments when we are not using them. That's after we have finished working for the day. This PR adds 2 jobs (one for GCE, one for AWS) that will shut down all (but excluded) environments every day at 19oo. 
### How to test

Use vagrant (`make vagrant`). The jobs will be disabled by default.
## BEWARE

If you enable and run jobs, you will shut down all environments (but excluded). Before you test, replace `make suspend-{{ platform }} DEPLOY_ENV=$environment` in the jobs with some benign NOOP, e.g. `echo Would shutdown $environment`

When you want to give it a final live test, wait before everyone is ready to have their environments shut down. Usually that's around the end of the day (say ~18:00)
#### Who can review

Anyone but @mtekel 
