### PR TITLE
[#100410408] terraform jobs: run make prep

### DIFF
--- a/templates/jobs/terraform-deploy.groovy.j2
+++ b/templates/jobs/terraform-deploy.groovy.j2
@@ -52,6 +52,7 @@ cp ~/.account.json gce/account.json
 # Terraform
 set -e
 [[ ${action} == "destroy" ]] && extraopts="-force"
+make prep
 
 # GCE
 cd gce


### PR DESCRIPTION
After merging https://github.com/alphagov/tsuru-ansible/pull/166 , ETCD_CLUSTER_ID files are prepared by make prep command. Add this to the terraform job, so that it runs correctly.
