### PR TITLE
[#101824268] suspend env. jobs: Don't fail when nothing to do

### DIFF
--- a/templates/jobs/suspend-environments.groovy.j2
+++ b/templates/jobs/suspend-environments.groovy.j2
@@ -66,7 +66,7 @@ ENVIRONMENTS=`echo "$NAT_HOSTS" | sed 's/-tsuru-nat.*// ; s/.\\+"//'`
 
 # 2. Exclude
 EXC=`echo "$EXCLUDE_ENV" | sed "s/ /|/g"`
-ENV=`echo "$ENVIRONMENTS" | grep -Ev $EXC`
+ENV=`echo "$ENVIRONMENTS" | grep -Ev $EXC || echo`
 
 # 3. Suspend
 echo "Suspending environments on {{ platform }}:"


### PR DESCRIPTION
When all the environments to be suspended are excluded, grep exits with 1, which is caught by the `set -e`. The job fails, but should succeed as there is nothing to do and all the environments that are supposed to be suspended (in this specific case none) are suspended. Fix this by adding `|| echo` after grep. This way job will not fail and the rest of the script will try to suspend "" environments. Which it will succeed.

The fix was already applied to AWS suspend job on jenkins, as it was failing because of this.
