### PR TITLE
suspend: Remove dupe kill ${SSH_AGENT_PID}

### DIFF
--- a/templates/jobs/suspend-environments.groovy.j2
+++ b/templates/jobs/suspend-environments.groovy.j2
@@ -78,7 +78,6 @@ for environment in $ENV ; do
   result=`expr $? + $result`
 done
 
-kill ${SSH_AGENT_PID}
 exit $result
 ''')
   }


### PR DESCRIPTION
This `kill` is already handled by the `trap` which is setup immediately
after `ssh-agent` is executed and always executed when this script exits (in
either success or failure).

By having this duplicate `kill` command at the end of the script, the
process was killed before the trap, and the trap produced this error in the
job output:

```
/tmp/hudson8936147716169821220.sh: line 1: kill: (457) - No such process
```
