### PR TITLE
Restrict build dashboard to CI related jobs

### DIFF
--- a/templates/views/build-monitor.groovy.j2
+++ b/templates/views/build-monitor.groovy.j2
@@ -1,6 +1,6 @@
 buildMonitorView('Build Monitor View') {
     description('Dashboard Listing Build Statuses')
     jobs {
-        regex('.*')
+        regex('ci-.*')
     }
 }


### PR DESCRIPTION
When deploying PR #42 I noticed that the suspend jobs weren't being updated
because the job `default-dsl-job` was disabled and not being run. I enabled
and ran it, which updated the suspend jobs correctly, but it also resulted
in _all_ of the jobs appearing on our dashboard build monitor.

Put it back to what it looked like before by restricting it to jobs related
to CI. These are the only ones that we should actively care about failing,
right now.

This wouldn't have been possible or as easy without a942337 :)
