### PR TITLE
Ansible use empty_inventory to avoid Boto error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ vagrant-provision:
 aws: aws-provision ansible-galaxy site
 
 aws-provision: 
-	ansible-playbook -i localhost, aws-provision.yml -v
+	ansible-playbook -i empty_inventory aws-provision.yml -v
 
 site: 
 	ansible-playbook -i ec2.py site.yml -v


### PR DESCRIPTION
Prevent the following error on my machine (OS X with Ansible installed to a
virtualenv) by borrowing this commit from another project:
alphagov/tsuru-ansible@aeab7213821f222d1fbc042baaf7ec6843021014

```
(ansible)➜  multicloud-deploy git:(master) ✗ make aws
ansible-playbook -i localhost, aws-provision.yml -v

PLAY [Provision a tooling infrastructure and Jenkins instance on AWS] *********

TASK: [create a tooling VPC] **************************************************
failed: [localhost] => {"failed": true, "parsed": false}
failed=True msg='boto required for this module'

FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************************************************************
           to retry, use: --limit @/Users/dcarley/aws-provision.retry

localhost                  : ok=0    changed=0    unreachable=0    failed=1

make: *** [aws-provision] Error 2
```
