### PR TITLE
[#106088684] and [#106184720] Create a Continuous Deivery Pipeline for the Trial environment

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -165,14 +165,14 @@
         job_template: smoke-test-cf
         target_environment_name: daily-build
         platform: aws
-        destroy: true
+        downstream_parameterized_trigger_job: ci-cf-destroy-daily-build-aws
     - include: jenkins_job.yml
       vars:
         job_name: ci-cf-smoke-and-destroy-daily-build-gce
         job_template: smoke-test-cf
         target_environment_name: daily-build
         platform: gce
-        destroy: true
+        downstream_parameterized_trigger_job: ci-cf-destroy-daily-build-gce
     - include: jenkins_job.yml
       vars:
         job_name: ci-cf-deploy-daily-build-aws

--- a/site.yml
+++ b/site.yml
@@ -180,6 +180,7 @@
         target_environment_name: daily-build
         poll_scm: "0 7 * * 1-5"
         platform: aws
+        downstream_parameterized_trigger_job: ci-cf-smoke-and-destroy-daily-build-aws
     - include: jenkins_job.yml
       vars:
         job_name: ci-cf-deploy-daily-build-gce
@@ -187,6 +188,7 @@
         target_environment_name: daily-build
         poll_scm: "0 7 * * 1-5"
         platform: gce
+        downstream_parameterized_trigger_job: ci-cf-smoke-and-destroy-daily-build-gce
     - include: jenkins_job.yml
       vars:
         job_name: ci-terraform-deploy

--- a/site.yml
+++ b/site.yml
@@ -268,6 +268,36 @@
         platform: "gce"
         exclude_env: "demo ci"
         cron_suspend_time: "0 19 * * *"
+    - include: jenkins_job.yml
+      vars:
+        job_name: stage-trial-cf-deploy-aws
+        job_template: cf-deploy
+        target_environment_name: stage-trial
+        platform: aws
+        poll_scm: "H/5 * * * *"
+        downstream_parameterized_trigger_job: stage-trial-cf-smoke-test-aws
+    - include: jenkins_job.yml
+      vars:
+        job_name: stage-trial-cf-smoke-test-aws
+        job_template: smoke-test-cf
+        target_environment_name: stage-trial
+        platform: aws
+        destroy: false
+        downstream_parameterized_trigger_job: trial-cf-deploy-aws
+    - include: jenkins_job.yml
+      vars:
+        job_name: trial-cf-deploy-aws
+        job_template: cf-deploy
+        target_environment_name: trial
+        platform: aws
+        downstream_parameterized_trigger_job: trial-cf-smoke-test-aws
+    - include: jenkins_job.yml
+      vars:
+        job_name: trial-cf-smoke-test-aws
+        job_template: smoke-test-cf
+        target_environment_name: trial
+        platform: aws
+        destroy: false
     - include: jenkins_view.yml
       vars:
         view_name: build-monitor

--- a/site.yml
+++ b/site.yml
@@ -311,6 +311,16 @@
         environment_regex: '^demo-.*'
         view_name: demo
         view_template: environment-view
+    - include: jenkins_view.yml
+      vars:
+        environment_regex: '^trial-.*'
+        view_name: trial
+        view_template: environment-view
+    - include: jenkins_view.yml
+      vars:
+        environment_regex: '^stage-.*'
+        view_name: stage
+        view_template: environment-view
 
     - name: execute dsl seed job for vagrant
       shell: "sleep 20 && curl -X POST 'http://127.0.0.1:8080/job/default-dsl-job/build'"

--- a/templates/jobs/cf-deploy.groovy.j2
+++ b/templates/jobs/cf-deploy.groovy.j2
@@ -28,11 +28,13 @@ job('{{ job_name }}') {
   }
   publishers {
     mailer("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk", false, true)
-    downstreamParameterized {
-      trigger("ci-cf-smoke-and-destroy-{{ target_environment_name }}-{{ platform }}", 'SUCCESS', true) {
-        currentBuild()
+    {% if downstream_parameterized_trigger_job is defined %}
+      downstreamParameterized {
+        trigger("{{ downstream_parameterized_trigger_job }}", 'SUCCESS', true) {
+          currentBuild()
+        }
       }
-    }
+    {% endif %}
   }
   steps {
 shell('''#!/bin/bash

--- a/templates/jobs/cf-destroy.groovy.j2
+++ b/templates/jobs/cf-destroy.groovy.j2
@@ -6,13 +6,15 @@ job('{{ job_name }}') {
   parameters {
     stringParam("DEPLOY_ENV", "{{ target_environment_name }}",
             "Select which environment you wish to run against")
+    stringParam("REF_NAME", "{{ reference_name }}",
+            "Select which branch or tag you wish to use")
   }
   scm {
     git {
       remote {
     url('https://github.com/alphagov/cf-terraform.git')
       }
-      branch('master')
+      branch('${REF_NAME}')
       createTag(false)
     }
   }

--- a/templates/jobs/smoke-test-cf.groovy.j2
+++ b/templates/jobs/smoke-test-cf.groovy.j2
@@ -28,13 +28,18 @@ job('{{ job_name }}') {
   }
   publishers {
     mailer("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk", false, true)
-    {% if destroy is defined and destroy %}
     downstreamParameterized {
-      trigger("ci-cf-destroy-{{ target_environment_name }}-{{ platform }}", 'SUCCESS', true) {
-        currentBuild()
-      }
+      {% if destroy is defined and destroy %}
+        trigger("ci-cf-destroy-{{ target_environment_name }}-{{ platform }}", 'SUCCESS', true) {
+          currentBuild()
+        }
+      {% endif %}
+      {% if downstream_parameterized_trigger_job is defined %}
+        trigger("{{ downstream_parameterized_trigger_job }}", 'SUCCESS', true) {
+          currentBuild()
+        }
+      {% endif %}
     }
-    {% endif %}
   }
   steps {
 shell('''#!/bin/bash

--- a/templates/jobs/smoke-test-cf.groovy.j2
+++ b/templates/jobs/smoke-test-cf.groovy.j2
@@ -29,11 +29,6 @@ job('{{ job_name }}') {
   publishers {
     mailer("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk", false, true)
     downstreamParameterized {
-      {% if destroy is defined and destroy %}
-        trigger("ci-cf-destroy-{{ target_environment_name }}-{{ platform }}", 'SUCCESS', true) {
-          currentBuild()
-        }
-      {% endif %}
       {% if downstream_parameterized_trigger_job is defined %}
         trigger("{{ downstream_parameterized_trigger_job }}", 'SUCCESS', true) {
           currentBuild()


### PR DESCRIPTION
## What

[Deploy to the Trial environment as part of the pipeline (CF)](https://www.pivotaltracker.com/story/show/106184720)

[Perform CI build on push](https://www.pivotaltracker.com/story/show/106088684)

Our current CF build pipeline runs once a day to rebuild from scratch. It would be useful to enhance this to have regular incremental builds based on merge to master to check if the latest build works.
## How this PR should be reviewed

This PR has been created to fit the following narrative:
- I want to:
  - Make the `downstreamParameterized` trigger a parameter rather than have it hard-coded so I can use it to trigger other types of job
  - Allow smoke tests to be able to trigger other downstream jobs
  - Allow someone to select what git ref or branch to use with the cf-destroy task in case you are using something other than master
  - Create the following Build Pipeline: stage-trial-cf-deploy-aws -> stage-trial-cf-smoke-test-aws -> trial-cf-deploy-aws -> trial-cf-smoke-test-aws
  - Create jenkins views for staging and trial jobs
## How to test this PR

A vagrant box has been provided for local testing, simply just:

```
vagrant up
```

Then browse to https://localhost:8443

You can view the following jobs:
- ci-cf-deploy-daily-build-aws
- ci-cf-deploy-daily-build-gce
- stage-trial-cf-deploy-aws
- stage-trial-cf-smoke-test-aws
- trial-cf-deploy-aws
- trial-cf-smoke-test-aws

You can also edit them in vagrant and remove any ``make` tasks and enable those jobs so they will run without doing anything.
## Who should review this PR
- A lovable leopard, if a suitably cute big cat is not to be found then anyone on the core team will do with the exception of @actionjack and @mtekel who worked on this story
