### PR TITLE
[#106191652] Add timeout to Cloud Foundry smoke tests

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -26,6 +26,7 @@
       - role-strategy
       - ansicolor
       - build-monitor-plugin
+      - build-timeout
 
     nginx_sites:
       ssl_reverse_proxy:

--- a/templates/jobs/smoke-test-cf.groovy.j2
+++ b/templates/jobs/smoke-test-cf.groovy.j2
@@ -25,6 +25,14 @@ job('{{ job_name }}') {
 {% endif %}
   wrappers {
     colorizeOutput()
+    {% if build_timeout is not defined %}
+    {% set build_timeout = '5' %}
+    {% endif %}
+    timeout {
+      absolute({{ build_timeout }})
+      failBuild()
+    }
+
   }
   publishers {
     mailer("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk", false, true)


### PR DESCRIPTION
[Run smoke tests regularly on trial platforms - CF](https://www.pivotaltracker.com/story/show/106191652)
## What

Add timeout to our smoke tests, because they can get stuck.
## How this PR should be reviewed

This PR has been written to follow this narrative:
- I want to:
  - Install the Jenkins [Build-timeout Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build-timeout+Plugin)
  - Set a 5 minute time-out to all Cloud Foundry smoke tests
## How to test this PR

A vagrant box has been provided for local testing, simply just:

```
vagrant up
```

Then browse to https://localhost:8443

And check the configuration of the following jobs:
- `*-cf-smoke-test-*`
## Pre-requisites on how to Implement this PR
- I recommend that you manually install the [Build-timeout Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Build-timeout+Plugin) because the security settings on our Jenkins server prevents installation of plugins unless you are authenticated so Ansible will fail on this step.
## Who should review and merge this PR

A Cool Cat, if a suitably mellow member of the feline species is unavailable then any member of the core team can use their tail to hit the merge button.
