### PR TITLE
[#106184714] deploy tsuru trial on aws

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,13 +1,14 @@
 # vim:ft=ansible:
 
-## from galaxy
-
-- src: geerlingguy.jenkins
+- src: https://github.com/geerlingguy/ansible-role-jenkins.git
   version: 1.2.3
-- src: jdauphant.nginx
+  name: geerlingguy.jenkins
+- src: https://github.com/jdauphant/ansible-role-nginx.git
   version: v1.3.4
+  name: jdauphant.nginx
 - src: https://github.com/alphagov/ansible-role-openconnect.git
   version: "0.1"
   name: openconnect
-- src: rvm_io.rvm1-ruby
+- src: https://github.com/rvm/rvm1-ansible.git
   version: v1.3.7
+  name: rvm_io.rvm1-ruby

--- a/site.yml
+++ b/site.yml
@@ -192,15 +192,30 @@
         downstream_parameterized_trigger_job: ci-cf-smoke-and-destroy-daily-build-gce
     - include: jenkins_job.yml
       vars:
-        job_name: ci-terraform-deploy
+        job_name: ci-terraform-deploy-aws
         job_template: terraform-deploy
         target_environment_name: ci
         poll_scm: "H/5 * * * *"
+        platform: aws
     - include: jenkins_job.yml
       vars:
-        job_name: demo-terraform-deploy
+        job_name: ci-terraform-deploy-gce
+        job_template: terraform-deploy
+        target_environment_name: ci
+        poll_scm: "H/5 * * * *"
+        platform: gce
+    - include: jenkins_job.yml
+      vars:
+        job_name: demo-terraform-deploy-aws
         job_template: terraform-deploy
         target_environment_name: demo
+        platform: aws
+    - include: jenkins_job.yml
+      vars:
+        job_name: demo-terraform-deploy-gce
+        job_template: terraform-deploy
+        target_environment_name: demo
+        platform: gce
     - include: jenkins_job.yml
       vars:
         job_name: ci-ansible-deploy-aws

--- a/site.yml
+++ b/site.yml
@@ -192,6 +192,19 @@
         downstream_parameterized_trigger_job: ci-cf-smoke-and-destroy-daily-build-gce
     - include: jenkins_job.yml
       vars:
+        job_name: trial-terraform-deploy-aws
+        job_template: terraform-deploy
+        target_environment_name: trial
+        platform: aws
+        upstream_jobs:
+        - "ci-smoke-test-aws"
+    - include: jenkins_job.yml
+      vars:
+        job_name: trial-ansible-deploy-aws
+        job_template: ansible-deploy-aws
+        target_environment_name: trial
+    - include: jenkins_job.yml
+      vars:
         job_name: ci-terraform-deploy-aws
         job_template: terraform-deploy
         target_environment_name: ci

--- a/templates/jobs/terraform-deploy.groovy.j2
+++ b/templates/jobs/terraform-deploy.groovy.j2
@@ -1,11 +1,11 @@
-job('{{ target_environment_name }}-terraform-deploy') {
-  description('Deploy and automatically update Terraform environments upon repository changes')
+job('{{ target_environment_name }}-terraform-deploy-{{ platform }}') {
+  description('Deploy and automatically update Terraform environments upon repository changes on {{ platform }}')
   {% if vagrant is defined %}
     disabled(shouldDisable = true)
   {% endif %}
   parameters {
     choiceParam("action", ["apply", "destroy"],
-                "Select if you want to apply changes to environments or destroy them.")
+            "Select if you want to apply changes to environments or destroy them.")
     stringParam("DEPLOY_ENV", "{{ target_environment_name }}",
             "Select which environment you wish to run terraform against")
     stringParam("REF_NAME", "{{ reference_name }}",
@@ -31,7 +31,7 @@ job('{{ target_environment_name }}-terraform-deploy') {
   publishers {
     mailer("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk", false, true)
     downstreamParameterized {
-      trigger("{{ target_environment_name }}-ansible-deploy-aws, {{ target_environment_name }}-ansible-deploy-gce", 'SUCCESS', true) {
+      trigger("{{ target_environment_name }}-ansible-deploy-{{ platform }}", 'SUCCESS', true) {
         currentBuild()
       }
     }
@@ -39,28 +39,23 @@ job('{{ target_environment_name }}-terraform-deploy') {
   steps {
     shell('''#!/bin/bash
 set -x
-home=`pwd`
-environment_name=${DEPLOY_ENV}
 
-# Set-up ssh keys and gce credentials
-mkdir -p gce/ssh aws/ssh
-cp ~/.ssh/* gce/ssh
-cp ~/.ssh/* aws/ssh
-cp ~/.account.json gce/account.json
+# Set-up ssh keys
+mkdir -p {{ platform }}/ssh
+cp ~/.ssh/* {{ platform }}/ssh
 
 # Terraform
 set -e
 [[ ${action} == "destroy" ]] && extraopts="-force"
 make prep
 
-# GCE
-cd gce
-terraform ${action} -var env=${environment_name} -input=false -state=${environment_name}-terraform.tfstate ${extraopts}
-
-# AWS
-cd ../aws
+cd {{ platform }}
+{% if platform == "gce" %}
+cp ~/.account.json ./account.json
+{% elif platform == "aws" %}
 . ~/.aws_credentials
-terraform ${action} -var env=${environment_name} -input=false -state=${environment_name}-terraform.tfstate ${extraopts}
+{% endif %}
+terraform ${action} -var env=${DEPLOY_ENV} -input=false -state=${DEPLOY_ENV}-terraform.tfstate ${extraopts}
 ''')
   }
 }

--- a/templates/jobs/terraform-deploy.groovy.j2
+++ b/templates/jobs/terraform-deploy.groovy.j2
@@ -20,11 +20,16 @@ job('{{ target_environment_name }}-terraform-deploy-{{ platform }}') {
       createTag(false)
     }
   }
-{% if poll_scm is defined %}
   triggers {
+   {% if poll_scm is defined %}
     scm("{{ poll_scm }}")
+   {% endif %}
+   {% if upstream_jobs is defined %}
+   {% for upstream_job in upstream_jobs %}
+    upstream('{{ upstream_job }}','SUCCESS')
+   {% endfor %}
+   {% endif %}
   }
-{% endif %}
   wrappers {
     colorizeOutput()
   }


### PR DESCRIPTION
## What?

We would like to deploy tsuru trial environment using jenkins. Whenever CI smoke tests succeed, indicating that the (latest) changes applied didn't break CI, we want to update TRIAL environment as well.
## How?

This is achieved by doing these changes and adjustments:
- terraform deploy job is parametrized to work on only one cloud provider (this enables us to have TRIAL environment in AWS only)
- existing terraform jobs are split into two - one for AWS, one for GCE deployment
- terraform job is updated to be triggerable by other jobs
- trial jobs are created and pipeline configured (CI smoketests -> TRIAL TF -> TRIAL ansible)
## Testing

Use vagrant (`make vagrant-up` or simply `vagrant up`). Be aware that if you really want to test the jobs they will actually build the trial environment which can take some time. You just need to enable all the jobs of the pipeline (see few lines above) and start the CI smoke test job.
## Who?

Anyone from the team can review and merge this PR but @Jonty or @mtekel.
# DEPLOYING TO JENKINS

After merging this PR, the changes should be applied against our jenkins server. Do it in this order:
1. run ansible. This will create the new jobs.
2. copy terraform state files from old terraform jobs to new ones:
   -  CI terraform/aws/ci-terraform.tfstate to CI terraform-aws/aws/ci-terraform.tfstate
   -  CI terraform/gce/ci-terraform.tfstate to CI terraform-gce/gce/ci-terraform.tfstate
   -  In case demo environment exists at the time of the merge, do the same for DEMO terraform job
3. Remove terraform job definitions from dsl job - delete:
   -   `/var/lib/jenkins/jobs/default-dsl-job/workspace/jobs/ci-terraform-deploy`
   -   `/var/lib/jenkins/jobs/default-dsl-job/workspace/jobs/demo-terraform-deploy`
     Otherwise the jobs would get re-created every time you run the dsl job (which is at least every time you run ansible).
4. Verify that terraform state files have been transferred correctly by running new TF jobs. They should do no changes to the environments.
5. You can now delete old CI and DEMO terraform jobs directly from jenkins.

**MAKE SURE YOU DON'T LOSE STATE OF EXISTING ENVIRONMENTS**
A good suggestion is to make additional backup of the state files.
