### PR TITLE
[#106665814] Run smoke tests regularly on tsuru trial

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -205,6 +205,13 @@
         target_environment_name: trial
     - include: jenkins_job.yml
       vars:
+        job_name: trial-smoke-test-aws
+        job_template: smoke-test
+        platform: "aws"
+        target_environment_name: trial
+        build_interval: "H/2 * * * *"
+    - include: jenkins_job.yml
+      vars:
         job_name: ci-terraform-deploy-aws
         job_template: terraform-deploy
         target_environment_name: ci

--- a/site.yml
+++ b/site.yml
@@ -138,6 +138,8 @@
       template: dest=~/setup_mail.groovy src=templates/setup_mail.groovy.j2
       notify:
         - configure admin email and smtp server
+    - name: Wipe old dsl jobs
+      file: path=/var/lib/jenkins/jobs/default-dsl-job/workspace/jobs state=absent
     - name: copy default dsl seed config.xml to jenkins master
       copy: src=dsl/config.xml dest=/tmp/config.xml owner=jenkins group=jenkins mode=0644
     - name: create default dsl seed job

--- a/templates/jobs/ansible-deploy-aws.groovy.j2
+++ b/templates/jobs/ansible-deploy-aws.groovy.j2
@@ -27,7 +27,9 @@ job('{{ target_environment_name }}-ansible-deploy-aws') {
     colorizeOutput()
   }
   publishers {
-    mailer("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk", false, true)
+  {% if vagrant is not defined %}
+    mailer("{{ email_notification_address | default("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk")}}")
+  {% endif %}
   }
   steps {
     shell('''#!/bin/bash

--- a/templates/jobs/ansible-deploy-gce.groovy.j2
+++ b/templates/jobs/ansible-deploy-gce.groovy.j2
@@ -27,7 +27,9 @@ job('{{ target_environment_name }}-ansible-deploy-gce') {
     colorizeOutput()
   }
   publishers {
-    mailer("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk", false, true)
+  {% if vagrant is not defined %}
+    mailer("{{ email_notification_address | default("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk")}}")
+  {% endif %}
   }
   steps {
     shell('''#!/bin/bash

--- a/templates/jobs/cf-deploy.groovy.j2
+++ b/templates/jobs/cf-deploy.groovy.j2
@@ -27,7 +27,9 @@ job('{{ job_name }}') {
     colorizeOutput()
   }
   publishers {
-    mailer("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk", false, true)
+  {% if vagrant is not defined %}
+    mailer("{{ email_notification_address | default("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk")}}")
+  {% endif %}
     {% if downstream_parameterized_trigger_job is defined %}
       downstreamParameterized {
         trigger("{{ downstream_parameterized_trigger_job }}", 'SUCCESS', true) {

--- a/templates/jobs/cf-destroy.groovy.j2
+++ b/templates/jobs/cf-destroy.groovy.j2
@@ -22,7 +22,9 @@ job('{{ job_name }}') {
     colorizeOutput()
   }
   publishers {
-    mailer("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk", false, true)
+  {% if vagrant is not defined %}
+    mailer("{{ email_notification_address | default("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk")}}")
+  {% endif %}
   }
   steps {
 shell('''#!/bin/bash

--- a/templates/jobs/smoke-test-cf.groovy.j2
+++ b/templates/jobs/smoke-test-cf.groovy.j2
@@ -40,7 +40,9 @@ job('{{ job_name }}') {
 
   }
   publishers {
-    mailer("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk", false, true)
+  {% if vagrant is not defined %}
+    mailer("{{ email_notification_address | default("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk")}}")
+  {% endif %}
     downstreamParameterized {
       {% if downstream_parameterized_trigger_job is defined %}
         trigger("{{ downstream_parameterized_trigger_job }}", 'SUCCESS', true) {

--- a/templates/jobs/smoke-test.groovy.j2
+++ b/templates/jobs/smoke-test.groovy.j2
@@ -32,6 +32,13 @@ job('{{ target_environment_name }}-smoke-test-{{ platform }}') {
   }
   wrappers {
     colorizeOutput()
+    {% if build_timeout is not defined %}
+    {% set build_timeout = '5' %}
+    {% endif %}
+    timeout {
+      absolute({{ build_timeout }})
+      failBuild()
+    }
   }
   publishers {
   {% if vagrant is not defined %}

--- a/templates/jobs/smoke-test.groovy.j2
+++ b/templates/jobs/smoke-test.groovy.j2
@@ -34,7 +34,9 @@ job('{{ target_environment_name }}-smoke-test-{{ platform }}') {
     colorizeOutput()
   }
   publishers {
+  {% if vagrant is not defined %}
     mailer("{{ email_notification_address | default("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk")}}")
+  {% endif %}
   }
   steps {
     shell('''#!/bin/bash

--- a/templates/jobs/suspend-environments.groovy.j2
+++ b/templates/jobs/suspend-environments.groovy.j2
@@ -23,7 +23,9 @@ job('{{ job_name }}') {
     colorizeOutput()
   }
   publishers {
+  {% if vagrant is not defined %}
     mailer("{{ email_notification_address | default("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk")}}")
+  {% endif %}
   }
   steps {
     shell('''#!/bin/bash

--- a/templates/jobs/terraform-deploy.groovy.j2
+++ b/templates/jobs/terraform-deploy.groovy.j2
@@ -34,7 +34,9 @@ job('{{ target_environment_name }}-terraform-deploy-{{ platform }}') {
     colorizeOutput()
   }
   publishers {
-    mailer("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk", false, true)
+  {% if vagrant is not defined %}
+    mailer("{{ email_notification_address | default("the-multi-cloud-paas-team@digital.cabinet-office.gov.uk")}}")
+  {% endif %}
     downstreamParameterized {
       trigger("{{ target_environment_name }}-ansible-deploy-{{ platform }}", 'SUCCESS', true) {
         currentBuild()


### PR DESCRIPTION
## What

Run smoketests regurarly on tsuru trial platform for the purpose of monitoring. The smoketests run every 2 minutes, so that the gap between issue happening and smoketests finding it is small. The smoketest jobs have 5 minutes timeout (they fail if they run longer), so that we can be alerted when the test gets stuck or platform gets a lot slower suddenly. 

In this PR we also do a bit boyscouting:
- disable email notifications in Vagrant - we don't want to send mails to the whole team when we do job development
- explicitly wipe the job definitions dir of the DSL job. This way we don't keep re-creating old, removed jobs.
## Testing

Use vagrant (`make vagrant-up` or simply `vagrant up`). Enable trial smoke tests job, wait and observe it running. You can test job timeouts by adding `sleep 300` just before the smoketst step in the job itself.
## Who?

Anyone from the team can review and merge this PR but @Jonty or @mtekel.
## Deploying to Jenkins

This PR depends on https://github.com/alphagov/multicloud-deploy/pull/50 being deployed to Jenkins. Before you start applying, do check if this was done. If so, then:
- Run ansible. This will create the new jobs. The jobs will run automatically.
- Verify general health of the server and that nothing else is broken (e.g. some other jobs not running or failing).
