### PR TITLE
#[106184720] Fix CF trial pipeline

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -320,13 +320,14 @@
         job_template: smoke-test-cf
         target_environment_name: stage-trial
         platform: aws
-        downstream_parameterized_trigger_job: trial-cf-deploy-aws
     - include: jenkins_job.yml
       vars:
         job_name: trial-cf-deploy-aws
         job_template: cf-deploy
         target_environment_name: trial
         platform: aws
+        upstream_jobs:
+        - "stage-trial-cf-smoke-test-aws"
         downstream_parameterized_trigger_job: trial-cf-smoke-test-aws
     - include: jenkins_job.yml
       vars:

--- a/templates/jobs/ansible-deploy-aws.groovy.j2
+++ b/templates/jobs/ansible-deploy-aws.groovy.j2
@@ -18,11 +18,16 @@ job('{{ target_environment_name }}-ansible-deploy-aws') {
       createTag(false)
     }
   }
-{% if poll_scm is defined %}
   triggers {
+   {% if poll_scm is defined %}
     scm("{{ poll_scm }}")
+   {% endif %}
+   {% if upstream_jobs is defined %}
+   {% for upstream_job in upstream_jobs %}
+    upstream('{{ upstream_job }}','SUCCESS')
+   {% endfor %}
+   {% endif %}
   }
-{% endif %}
   wrappers {
     colorizeOutput()
   }

--- a/templates/jobs/ansible-deploy-aws.groovy.j2
+++ b/templates/jobs/ansible-deploy-aws.groovy.j2
@@ -55,12 +55,10 @@ virtualenv .venv
 [[ -f /usr/bin/figlet ]] && figlet Installing python dependencies
 pip install -Ur requirements.txt
 
-[[ -f /usr/bin/figlet ]] \
-  && figlet Refreshing ec2 inventory cache
+[[ -f /usr/bin/figlet ]] && figlet Refreshing ec2 inventory cache
 ./ec2.py --refresh-cache > /dev/null 2>&1 && echo done...
 
-[[ -f /usr/bin/figlet ]] \
-  && figlet Running ansible against ${DEPLOY_ENV} environment
+[[ -f /usr/bin/figlet ]] && figlet Running ansible against ${DEPLOY_ENV} environment
 make aws
 
 kill ${SSH_AGENT_PID}

--- a/templates/jobs/ansible-deploy-aws.groovy.j2
+++ b/templates/jobs/ansible-deploy-aws.groovy.j2
@@ -59,7 +59,7 @@ pip install -Ur requirements.txt
 ./ec2.py --refresh-cache > /dev/null 2>&1 && echo done...
 
 [[ -f /usr/bin/figlet ]] && figlet Running ansible against ${DEPLOY_ENV} environment
-make aws
+make aws ARGS='-v'
 
 kill ${SSH_AGENT_PID}
 ''')

--- a/templates/jobs/ansible-deploy-gce.groovy.j2
+++ b/templates/jobs/ansible-deploy-gce.groovy.j2
@@ -57,7 +57,7 @@ virtualenv .venv
 pip install -Ur requirements.txt
 
 [[ -f /usr/bin/figlet ]] && figlet Running ansible against ${DEPLOY_ENV} environment
-make gce
+make gce ARGS='-v'
 
 kill ${SSH_AGENT_PID}
 ''')

--- a/templates/jobs/ansible-deploy-gce.groovy.j2
+++ b/templates/jobs/ansible-deploy-gce.groovy.j2
@@ -56,8 +56,7 @@ virtualenv .venv
 [[ -f /usr/bin/figlet ]] && figlet Installing python dependencies
 pip install -Ur requirements.txt
 
-[[ -f /usr/bin/figlet ]] && \
- figlet Running ansible against ${DEPLOY_ENV} environment
+[[ -f /usr/bin/figlet ]] && figlet Running ansible against ${DEPLOY_ENV} environment
 make gce
 
 kill ${SSH_AGENT_PID}

--- a/templates/jobs/ansible-deploy-gce.groovy.j2
+++ b/templates/jobs/ansible-deploy-gce.groovy.j2
@@ -18,11 +18,16 @@ job('{{ target_environment_name }}-ansible-deploy-gce') {
       createTag(false)
     }
   }
-{% if poll_scm is defined %}
   triggers {
+   {% if poll_scm is defined %}
     scm("{{ poll_scm }}")
+   {% endif %}
+   {% if upstream_jobs is defined %}
+   {% for upstream_job in upstream_jobs %}
+    upstream('{{ upstream_job }}','SUCCESS')
+   {% endfor %}
+   {% endif %}
   }
-{% endif %}
   wrappers {
     colorizeOutput()
   }

--- a/templates/jobs/cf-deploy.groovy.j2
+++ b/templates/jobs/cf-deploy.groovy.j2
@@ -18,11 +18,16 @@ job('{{ job_name }}') {
       createTag(false)
     }
   }
-{% if poll_scm is defined %}
   triggers {
+   {% if poll_scm is defined %}
     scm("{{ poll_scm }}")
+   {% endif %}
+   {% if upstream_jobs is defined %}
+   {% for upstream_job in upstream_jobs %}
+    upstream('{{ upstream_job }}','SUCCESS')
+   {% endfor %}
+   {% endif %}
   }
-{% endif %}
   wrappers {
     colorizeOutput()
   }

--- a/templates/jobs/smoke-test-cf.groovy.j2
+++ b/templates/jobs/smoke-test-cf.groovy.j2
@@ -26,6 +26,11 @@ job('{{ job_name }}') {
     {% if build_interval is defined %}
       cron("{{ build_interval }}")
     {% endif %}
+    {% if upstream_jobs is defined %}
+    {% for upstream_job in upstream_jobs %}
+      upstream('{{ upstream_job }}','SUCCESS')
+    {% endfor %}
+    {% endif %}
   }
 
   wrappers {


### PR DESCRIPTION
Currently our trial deploy job is triggered by stage-trial smoketest job. When using this downstream trigger, all jobs parameters and environment variables are passed. The trial-deploy job then deploys stage-trial instead. To fix this, I have swapped order of triggering: Now trial deploy triggers itself (using own and correct environment name) upon smoketest success.

This PR contains also a bit of cleanup and turning on verbose mode on ansible deploy, so that we can see what ansible is really doing.
