### PR TITLE
[#107994314] Configure trial environment to use ssl certs

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -329,6 +329,7 @@
         upstream_jobs:
         - "stage-trial-cf-smoke-test-aws"
         downstream_parameterized_trigger_job: trial-cf-smoke-test-aws
+        deploy_trial_ssl_certificates: true
     - include: jenkins_job.yml
       vars:
         job_name: trial-cf-smoke-test-aws

--- a/templates/jobs/cf-deploy.groovy.j2
+++ b/templates/jobs/cf-deploy.groovy.j2
@@ -67,7 +67,12 @@ echo Retrieving Terraform state
 ln -sf ~/${DEPLOY_ENV}_{{ platform }}.tfstate {{ platform }}/${DEPLOY_ENV}.tfstate
 ln -sf ~/${DEPLOY_ENV}_{{ platform }}.tfstate.backup {{ platform }}/${DEPLOY_ENV}.tfstate.backup
 
+{% if deploy_trial_ssl_certificates is defined %}
+make {{ platform }}-trial DEPLOY_ENV=${DEPLOY_ENV} ROOT_PASS_DIR=jenkins
+{% else %}
 make {{ platform }} DEPLOY_ENV=${DEPLOY_ENV} ROOT_PASS_DIR=jenkins
+{% endif %}
+
 ''')
   }
 


### PR DESCRIPTION
[Install SSL certificates for Trial](https://www.pivotaltracker.com/story/show/107994314)
## What

Configure `trial` environment to use the new aws-trial Makefile target that will deploy root CA certificate signed certificates for the trial environment.
## How this PR should be reviewed

This PR has been written to follow this narrative:
- I want to:
  - Configure the `trial` environment to use a different Makefile target than every other environment, the new target will install SSL certificates that are to be used by the `trial` environment only.
## How to test this PR

A vagrant box has been provided for local testing, simply just:

```
vagrant up
```

Then browse to https://localhost:8443

And check the configuration of the following jobs:
- `trial-cf-deploy-aws`
## Who should review and merge this PR

A Bountiful Cow, if a generous bovine is unavailable then any member of the core team can use their moo-skills to hit the merge button.
