### PR TITLE
[#108062984] Open the trial environment to IP addresses beyond AH

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -326,6 +326,7 @@
         job_template: cf-deploy
         target_environment_name: trial
         platform: aws
+        extra_options: "WEB_ACCESS_CIDRS=0.0.0.0/0"
         upstream_jobs:
         - "stage-trial-cf-smoke-test-aws"
         downstream_parameterized_trigger_job: trial-cf-smoke-test-aws

--- a/templates/jobs/cf-deploy.groovy.j2
+++ b/templates/jobs/cf-deploy.groovy.j2
@@ -8,6 +8,8 @@ job('{{ job_name }}') {
             "Select which environment you wish to run against")
     stringParam("REF_NAME", "{{ reference_name }}",
             "Select which branch or tag you wish to use")
+    stringParam("EXTRA_OPTIONS", "{{ extra_options | default('') }}",
+            "Extra options to pass to the make command")
   }
   scm {
     git {
@@ -67,7 +69,7 @@ echo Retrieving Terraform state
 ln -sf ~/${DEPLOY_ENV}_{{ platform }}.tfstate {{ platform }}/${DEPLOY_ENV}.tfstate
 ln -sf ~/${DEPLOY_ENV}_{{ platform }}.tfstate.backup {{ platform }}/${DEPLOY_ENV}.tfstate.backup
 
-make {{ platform }} DEPLOY_ENV=${DEPLOY_ENV} ROOT_PASS_DIR=jenkins
+make {{ platform }} DEPLOY_ENV=${DEPLOY_ENV} ROOT_PASS_DIR=jenkins ${EXTRA_OPTIONS}
 ''')
   }
 


### PR DESCRIPTION
**What**

We want to (optionally) open up web access to deployed apps in the trial environment so they are available from anywhere and not just aviation house ips.

Relies on https://github.com/alphagov/cf-terraform/pull/71

**How this PR should be reviewed**

This PR should reviewed in the following context:
- I want the trial environment to be externally accessible
- I want to be able to pass extra parameters to the make stage of the cf-deploy jenkins jobs

**How to test this PR**
A vagrant box has been provided for local testing, simply just:

```
vagrant up
```

Then browse to https://localhost:8443

And check the configuration of the following jobs:
- `trial-cf-deploy-aws`

**Who should review this PR**
- Anyone in the core team except @jimconner who I paired with
