### PR TITLE
[#108440520] Fix the dashboard so that it fills the whole screen.

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -4,8 +4,8 @@
     <title>Dashboard</title>
     <link rel="icon" type="image/png" href="favicon-32.png">
     <style>
-    body { background: #333; }
-    .box { height: 1000px; float: left; }
+    body { background: #333; margin: 8px; }
+    .box { height: 1064px; float: left; }
     #box-left { width: 50%; }
     #box-right { width: 50%; }
     iframe { margin: 0; border: 0; }


### PR DESCRIPTION
This was set to 1000px high, so was leaving a blank space at the bottom
on a 1080p display. Setting this to 1064px allows it to fill the whole
screen (allowing for the 8px padding top and bottom).

The 8px margin was being added by the Safari user-agent stylesheet, so I
added it here to make it explicit, and also make it more obvious why the
height is set to 1064px.
