### PR TITLE
Kill the spawned ssh-agent on job completion

### DIFF
--- a/templates/jobs/cf-deploy.groovy.j2
+++ b/templates/jobs/cf-deploy.groovy.j2
@@ -58,7 +58,7 @@ export TF_VAR_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 echo Setting up ssh-agent and cleanup trap
 eval $(ssh-agent) && ssh-add ~/.ssh/insecure-deployer
 set -e
-trap "kill ${SSH_AGENT_PID}" ERR
+trap "ssh-agent -k" EXIT
 
 echo Retrieving Terraform state
 ln -sf ~/${DEPLOY_ENV}_{{ platform }}.tfstate {{ platform }}/${DEPLOY_ENV}.tfstate

--- a/templates/jobs/cf-destroy.groovy.j2
+++ b/templates/jobs/cf-destroy.groovy.j2
@@ -39,7 +39,7 @@ export TF_VAR_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 echo Setting up ssh-agent and cleanup trap
 eval $(ssh-agent) && ssh-add ~/.ssh/insecure-deployer
 set -e
-trap "kill ${SSH_AGENT_PID}" ERR
+trap "ssh-agent -k" EXIT
 
 echo Retrieving Terraform state
 ln -sf ~/${DEPLOY_ENV}_{{ platform }}.tfstate {{ platform }}/${DEPLOY_ENV}.tfstate

--- a/templates/jobs/smoke-test-cf.groovy.j2
+++ b/templates/jobs/smoke-test-cf.groovy.j2
@@ -69,7 +69,7 @@ export TF_VAR_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 echo Setting up ssh-agent and cleanup trap
 eval $(ssh-agent) && ssh-add ~/.ssh/insecure-deployer
 set -e
-trap "kill ${SSH_AGENT_PID}" ERR
+trap "ssh-agent -k" EXIT
 
 echo Retrieving Terraform state
 ln -sf ~/${DEPLOY_ENV}_{{ platform }}.tfstate {{ platform }}/${DEPLOY_ENV}.tfstate


### PR DESCRIPTION
Currently we leak ssh-agent processes every time these jobs are run.
Running `ssh-agent -k` at job EXIT will terminate the
agent that exported SSH_AGENT_PID into the current environment.
