### PR TITLE
Fix fourth-wall URL.

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -38,7 +38,7 @@ function getParameterByName(name) {
 var JENKINS_URL = getParameterByName("JENKINS_URL")
       || "https://deploy.tools.paas.alphagov.co.uk",
     FOURTH_WALL_URL = getParameterByName("FOURTH_WALL_URL")
-      || "https://alphagov.github.io/fourth-wall",
+      || "https://alphagov.github.io/fourth-wall/",
     LEFT_WIDTH = getParameterByName("LEFT_WIDTH") || "50",
     RIGHT_WIDTH = getParameterByName("RIGHT_WIDTH") || "50";
 


### PR DESCRIPTION
The fourth-wall URL requires a trailing '/'.  Without this, the page
returns a 404 (note that http://alphagov.github.io/fourth-wall/?foo=bar
works, whereas http://alphagov.github.io/fourth-wall?foo=bar 404s).

I suspect that github pages may have changed this behaviour recently. If
you use the URL without the trailing / with no query params, it gets
redirected, but not when query params are included.
