### PR TITLE
Add ntpd to Jenkins machine.

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -75,6 +75,7 @@
         - gnupg-agent
         - pwgen
         - pinentry-curses
+        - ntp
     - name: Test if pass is installed
       shell: /usr/bin/pass --version || echo pass not installed
       register: pass_version


### PR DESCRIPTION
without this, the time drifts on this machine.  If the drift exceeds 5
minutes, authentication with AWS will fail.
